### PR TITLE
Updated caffe.py to prevent hard failure if net_ isn't found

### DIFF
--- a/nolearn/caffe.py
+++ b/nolearn/caffe.py
@@ -147,7 +147,7 @@ class CaffeImageNet(ChunkedTransform, BaseEstimator):
 
     def __getstate__(self):
         d = self.__dict__.copy()
-        d.pop('net_')
+        d.pop('net_', None)
         return d
 
     def __setstate__(self, state):


### PR DESCRIPTION
I've been running with this change locally as a workaround to the pop() failing if it can't find 'net_'.
