### PR TITLE
Replace 'loss' parameter by 'objective' which has a more interesting interface.

### DIFF
--- a/nolearn/metrics.py
+++ b/nolearn/metrics.py
@@ -71,7 +71,7 @@ class LearningCurve(object):
             print("          n      train      test")
 
         for frac in np.linspace(0.1, 1.0, num=steps):
-            frac_size = X_train.shape[0] * frac
+            frac_size = int(X_train.shape[0] * frac)
             sizes.append(frac_size)
             X_train1 = X_train[:frac_size]
             y_train1 = y_train[:frac_size]

--- a/nolearn/tests/test_lasagne.py
+++ b/nolearn/tests/test_lasagne.py
@@ -155,8 +155,9 @@ def test_lasagne_functional_grid_search(mnist, monkeypatch):
 
 def test_clone():
     from nolearn.lasagne import NeuralNet
-    from nolearn.lasagne import negative_log_likelihood
+    from nolearn.lasagne import categorical_crossentropy
     from nolearn.lasagne import BatchIterator
+    from nolearn.lasagne import Objective
 
     params = dict(
         layers=[
@@ -176,7 +177,8 @@ def test_clone():
         update_momentum=0.9,
 
         regression=False,
-        loss=negative_log_likelihood,
+        objective=Objective,
+        objective_loss_function=categorical_crossentropy,
         batch_iterator_train=BatchIterator(batch_size=100),
         X_tensor_type=T.matrix,
         y_tensor_type=T.ivector,
@@ -197,6 +199,8 @@ def test_clone():
         'batch_iterator_train',
         'batch_iterator_test',
         'output_nonlinearity',
+        'loss',
+        'objective'
         ):
         for par in (params, params1, params2):
             par.pop(ignore, None)
@@ -296,16 +300,19 @@ class TestInitializeLayers:
             )
         out = nn.initialize_layers(nn.layers)
 
-        input.assert_called_with(shape=(10, 10))
+        input.assert_called_with(
+            name='input', shape=(10, 10))
         nn.layers_['input'] is input.return_value
 
-        hidden1.assert_called_with(input.return_value, some='param')
+        hidden1.assert_called_with(
+            input.return_value, name='hidden1', some='param')
         nn.layers_['hidden1'] is hidden1.return_value
 
-        hidden2.assert_called_with(hidden1.return_value)
+        hidden2.assert_called_with(
+            hidden1.return_value, name='hidden2')
         nn.layers_['hidden2'] is hidden2.return_value
 
-        output.assert_called_with(hidden2.return_value)
+        output.assert_called_with(hidden2.return_value, name='output')
 
         assert out is nn.layers_['output']
 
@@ -326,8 +333,9 @@ class TestInitializeLayers:
             )
         nn.initialize_layers(nn.layers)
 
-        input.assert_called_with(shape=(10, 10))
-        hidden1.assert_called_with(input.return_value)
-        hidden2.assert_called_with(input.return_value)
-        concat.assert_called_with([hidden1.return_value, hidden2.return_value])
-        output.assert_called_with(concat.return_value)
+        input.assert_called_with(name='input', shape=(10, 10))
+        hidden1.assert_called_with(input.return_value, name='hidden1')
+        hidden2.assert_called_with(input.return_value, name='hidden2')
+        concat.assert_called_with([hidden1.return_value, hidden2.return_value],
+                                  name='concat')
+        output.assert_called_with(concat.return_value, name='output')

--- a/nolearn/tests/test_metrics.py
+++ b/nolearn/tests/test_metrics.py
@@ -44,7 +44,7 @@ def test_learning_curve():
     scores_train, scores_test, sizes = _learning_curve(learning_curve)
     assert len(scores_train) == 5
     assert len(scores_test) == 5
-    assert sizes[0] == 22.5
+    assert sizes[0] == 22
     assert sizes[-1] == 225.0
 
 
@@ -54,5 +54,5 @@ def test_learning_curve_logloss():
     scores_train, scores_test, sizes = _learning_curve(learning_curve_logloss)
     assert len(scores_train) == 5
     assert len(scores_test) == 5
-    assert sizes[0] == 22.5
+    assert sizes[0] == 22
     assert sizes[-1] == 225.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 joblib==0.8.4
 scikit-learn==0.15.2
 git+https://github.com/Theano/Theano.git@b84464261ffa1d451097ac5e5243dcd8f7e0ff62#egg=Theano
-git+https://github.com/benanne/Lasagne.git@490f45de4d1e9f77969a729588f6971744f423e9#egg=Lasagne
+git+https://github.com/benanne/Lasagne.git@441d191bc967ee4f87d75a6b60330bc7d69790c7#egg=Lasagne

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 joblib==0.8.4
 scikit-learn==0.15.2
 git+https://github.com/Theano/Theano.git@b84464261ffa1d451097ac5e5243dcd8f7e0ff62#egg=Theano
-git+https://github.com/benanne/Lasagne.git@441d191bc967ee4f87d75a6b60330bc7d69790c7#egg=Lasagne
+git+https://github.com/benanne/Lasagne.git@b3f291383ceeb4b1fa64a230607455a2f1bb687b#egg=Lasagne


### PR DESCRIPTION
Adds a more interesting interface for specifying losses.  The `loss` parameter is now deprecated, and one should use `objective` instead.  Here's an example of an 'Objective' implementation from `nolearn.lasagne` itself.

```python
class LossObjective(object):
    def __init__(self, loss_function):
        self.loss_function = loss_function

    def __call__(self, layers, X, y, deterministic=False):
        output_layer = layers['output']
        return self.loss_function(
            output_layer.get_output(X, deterministic=deterministic), y)
```

@cancan101 Let me know if this makes sense to you, and if it would fix #14.