### PR TITLE
Feature: detailed layer info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
-  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy
+  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy matplotlib
 install:
   - travis_retry pip install -r requirements.txt
   - travis_retry python setup.py dev

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -28,7 +28,7 @@ from .utils import _dict
 from .utils import _list
 from .utils import ansi
 from .utils import get_conv_infos
-from .utils import layers_have_conv2d
+from .utils import is_conv2d
 
 
 class BatchIterator(object):
@@ -118,7 +118,6 @@ class NeuralNet(BaseEstimator):
             assert not hasattr(self, key)
         vars(self).update(kwargs)
         self._kwarg_keys = list(kwargs.keys())
-        self._check_for_unused_kwargs()
 
         self.train_history_ = []
 
@@ -129,7 +128,7 @@ class NeuralNet(BaseEstimator):
                 )
 
     def _check_for_unused_kwargs(self):
-        names = [n for n, _ in self.layers] + ['update', 'objective']
+        names = list(self.layers_.keys()) + ['update', 'objective']
         for k in self._kwarg_keys:
             for n in names:
                 prefix = '{}_'.format(n)
@@ -145,6 +144,7 @@ class NeuralNet(BaseEstimator):
         out = getattr(self, '_output_layer', None)
         if out is None:
             out = self._output_layer = self.initialize_layers()
+        self._check_for_unused_kwargs()
 
         iter_funcs = self._create_iter_funcs(
             self.layers_, self.objective, self.update,
@@ -174,26 +174,44 @@ class NeuralNet(BaseEstimator):
     def initialize_layers(self, layers=None):
         if layers is not None:
             self.layers = layers
-
         self.layers_ = OrderedDict()
-        input_layer_name, input_layer_factory = self.layers[0]
-        input_layer_params = self._get_params_for(input_layer_name)
-        layer = input_layer_factory(
-            name=input_layer_name, **input_layer_params)
-        self.layers_[input_layer_name] = layer
 
-        for (layer_name, layer_factory) in self.layers[1:]:
-            layer_params = self._get_params_for(layer_name)
-            incoming = layer_params.pop('incoming', None)
-            if incoming is not None:
-                if isinstance(incoming, (list, tuple)):
-                    layer = [self.layers_[name] for name in incoming]
+        layer = None
+        for i, layer_def in enumerate(self.layers):
+
+            if isinstance(layer_def[0], str):
+                # The legacy format: ('name', Layer)
+                layer_name, layer_factory = layer_def
+                layer_kwargs = {'name': layer_name}
+            else:
+                # New format: (Layer, {'layer': 'kwargs'})
+                layer_factory, layer_kwargs = layer_def
+
+            if 'name' not in layer_kwargs:
+                layer_kwargs['name'] = "{}{}".format(
+                    layer_factory.__class__.__name__.lower(), i)
+                                  
+            more_params = self._get_params_for(layer_kwargs['name'])
+            layer_kwargs.update(more_params)
+
+            # Any layer other than the first one is assumed to require
+            # an 'incoming' paramter.  By default, we'll use the
+            # previous layer:
+            if i > 0:
+                incoming = layer_kwargs.pop('incoming', None)
+                if incoming is not None:
+                    if isinstance(incoming, (list, tuple)):
+                        layer_kwargs['incoming'] = [
+                            self.layers_[name] for name in incoming]
+                    else:
+                        layer_kwargs['incoming'] = self.layers_[incoming]
                 else:
-                    layer = self.layers_[incoming]
-            layer = layer_factory(layer, name=layer_name, **layer_params)
-            self.layers_[layer_name] = layer
+                    layer_kwargs['incoming'] = layer
 
-        return self.layers_['output']
+            layer = layer_factory(**layer_kwargs)
+            self.layers_[layer_kwargs['name']] = layer
+
+        return layer
 
     def _create_iter_funcs(self, layers, objective, update, input_type,
                            output_type):
@@ -202,7 +220,7 @@ class NeuralNet(BaseEstimator):
         X_batch = input_type('x_batch')
         y_batch = output_type('y_batch')
 
-        output_layer = layers['output']
+        output_layer = list(layers.values())[-1]
         objective_params = self._get_params_for('objective')
         obj = objective(output_layer, **objective_params)
         if not hasattr(obj, 'layers'):
@@ -437,8 +455,8 @@ class NeuralNet(BaseEstimator):
         print("## Layer information")
 
         layers = self.layers_.values()
-        contains_conv2d = layers_have_conv2d(layers)
-        if contains_conv2d and (self.verbose > 1):
+        layers_contain_conv2d = is_conv2d(layers)
+        if layers_contain_conv2d and (self.verbose > 1):
             self._print_layer_info_conv()
         else:
             self._print_layer_info_plain()

--- a/nolearn/lasagne/utils.py
+++ b/nolearn/lasagne/utils.py
@@ -1,0 +1,179 @@
+import operator as op
+
+from lasagne.layers import Conv2DLayer
+from lasagne.layers import MaxPool2DLayer
+try:
+    from lasagne.layers.cuda_convnet import Conv2DCCLayer
+    from lasagne.layers.cuda_convnet import MaxPool2DCCLayer
+except ImportError:
+    Conv2DCCLayer = Conv2DLayer
+    MaxPool2DCCLayer = MaxPool2DLayer
+import numpy as np
+from tabulate import tabulate
+
+
+class _list(list):
+    pass
+
+
+class _dict(dict):
+    def __contains__(self, key):
+        return True
+
+
+class ansi:
+    BLUE = '\033[94m'
+    CYAN = '\033[36m'
+    GREEN = '\033[32m'
+    MAGENTA = '\033[35m'
+    RED = '\033[31m'
+    ENDC = '\033[0m'
+
+
+def layers_have_conv2d(layers):
+    try:
+        return any([isinstance(layer, (Conv2DLayer, Conv2DCCLayer))
+                    for layer in layers])
+    except TypeError:
+        return isinstance(layers, (Conv2DLayer, Conv2DCCLayer))
+
+
+def layers_have_maxpool2d(layers):
+    try:
+        return any([isinstance(layer, (MaxPool2DLayer, MaxPool2DCCLayer))
+                    for layer in layers])
+    except TypeError:
+        return isinstance(layers, (MaxPool2DLayer, MaxPool2DCCLayer))
+
+
+def get_real_filter(layers, img_size):
+    """Get the real filter sizes of each layer involved in
+    convoluation. See Xudong Cao:
+    https://www.kaggle.com/c/datasciencebowl/forums/t/13166/happy-lantern-festival-report-and-code
+
+    This does not yet take into consideration feature pooling,
+    padding, striding and similar gimmicks.
+
+    """
+    # imports here to prevent circular dependencies
+    real_filter = np.zeros((len(layers), 2))
+    conv_mode = True
+    first_conv_layer = True
+    expon = np.ones((1, 2))
+
+    for i, layer in enumerate(layers[1:]):
+        j = i + 1
+        if not conv_mode:
+            real_filter[j] = img_size
+            continue
+
+        if layers_have_conv2d(layer):
+            if not first_conv_layer:
+                new_filter = np.array(layer.filter_size) * expon
+                real_filter[j] = new_filter
+            else:
+                new_filter = np.array(layer.filter_size) * expon
+                real_filter[j] = new_filter
+                first_conv_layer = False
+        elif layers_have_maxpool2d(layer):
+            real_filter[j] = real_filter[i]
+            expon *= np.array(layer.ds)
+        else:
+            conv_mode = False
+            real_filter[j] = img_size
+
+    real_filter[0] = img_size
+    return real_filter
+
+
+def get_receptive_field(layers, img_size):
+    """Get the real filter sizes of each layer involved in
+    convoluation. See Xudong Cao:
+    https://www.kaggle.com/c/datasciencebowl/forums/t/13166/happy-lantern-festival-report-and-code
+
+    This does not yet take into consideration feature pooling,
+    padding, striding and similar gimmicks.
+
+    """
+    receptive_field = np.zeros((len(layers), 2))
+    conv_mode = True
+    first_conv_layer = True
+    expon = np.ones((1, 2))
+
+    for i, layer in enumerate(layers[1:]):
+        j = i + 1
+        if not conv_mode:
+            receptive_field[j] = img_size
+            continue
+
+        if layers_have_conv2d(layer):
+            if not first_conv_layer:
+                last_field = receptive_field[i]
+                new_field = (last_field + expon *
+                             (np.array(layer.filter_size) - 1))
+                receptive_field[j] = new_field
+            else:
+                receptive_field[j] = layer.filter_size
+                first_conv_layer = False
+        elif layers_have_maxpool2d(layer):
+            receptive_field[j] = receptive_field[i]
+            expon *= np.array(layer.ds)
+        else:
+            conv_mode = False
+            receptive_field[j] = img_size
+
+    receptive_field[0] = img_size
+    return receptive_field
+
+
+def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
+                   detailed=False):
+    CYA = ansi.CYAN
+    END = ansi.ENDC
+    MAG = ansi.MAGENTA
+    RED = ansi.RED
+
+    layers = net.layers_.values()
+    img_size = net.layers_['input'].get_output_shape()[2:]
+
+    header = ['name', 'size', 'total', 'cap. Y [%]', 'cap. X [%]',
+              'cov. Y [%]', 'cov. X [%]']
+    if detailed:
+        header += ['filter Y', 'filter X', 'field Y', 'field X']
+
+    shapes = [layer.get_output_shape()[1:] for layer in layers]
+    totals = [str(reduce(op.mul, shape)) for shape in shapes]
+    shapes = ['x'.join(map(str, shape)) for shape in shapes]
+    shapes = np.array(shapes).reshape(-1, 1)
+    totals = np.array(totals).reshape(-1, 1)
+
+    real_filters = get_real_filter(layers, img_size)
+    receptive_fields = get_receptive_field(layers, img_size)
+    capacity = 100. * real_filters / receptive_fields
+    capacity[np.negative(np.isfinite(capacity))] = 1
+    img_coverage = 100. * receptive_fields / img_size
+    layer_names = [layer.name if layer.name
+                   else str(layer).rsplit('.')[-1].split(' ')[0]
+                   for layer in layers]
+
+    colored_names = []
+    for name, (covy, covx), (capy, capx) in zip(
+            layer_names, img_coverage, capacity):
+        if (
+                ((covy > 100) or (covx > 100)) and
+                ((capy < min_capacity) or (capx < min_capacity))
+        ):
+            name = "{}{}{}".format(RED, name, END)
+        elif (covy > 100) or (covx > 100):
+            name = "{}{}{}".format(CYA, name, END)
+        elif (capy < min_capacity) or (capx < min_capacity):
+            name = "{}{}{}".format(MAG, name, END)
+        colored_names.append(name)
+    colored_names = np.array(colored_names).reshape(-1, 1)
+
+    table = np.hstack((colored_names, shapes, totals, capacity, img_coverage))
+    if detailed:
+        table = np.hstack((table, real_filters.astype(int),
+                           receptive_fields.astype(int)))
+
+    return tabulate(table, header, tablefmt=tablefmt, floatfmt='.2f')

--- a/nolearn/lasagne/visualize.py
+++ b/nolearn/lasagne/visualize.py
@@ -1,0 +1,124 @@
+from itertools import product
+
+import matplotlib.pyplot as plt
+import numpy as np
+import theano
+import theano.tensor as T
+
+from .utils import occlusion_heatmap
+
+
+def plot_loss(net):
+    train_loss = [row['train_loss'] for row in net.train_history_]
+    valid_loss = [row['valid_loss'] for row in net.train_history_]
+    plt.plot(train_loss, label='train loss')
+    plt.plot(valid_loss, label='valid loss')
+    plt.legend(loc='best')
+
+
+def plot_conv_weights(layer, figsize=(6, 6)):
+    """Plot the weights of a specific layer. Only really makes sense
+    with convolutional layers.
+    Parameters
+    ----------
+    layer : lasagne.layers.Layer
+    """
+    W = layer.W.get_value()
+    shape = W.shape
+    nrows = np.ceil(np.sqrt(shape[0])).astype(int)
+    ncols = nrows
+    for feature_map in range(shape[1]):
+        figs, axes = plt.subplots(nrows, ncols, figsize=figsize)
+        for ax in axes.flatten():
+            ax.set_xticks([])
+            ax.set_yticks([])
+            ax.axis('off')
+        for i, (r, c) in enumerate(product(range(nrows), range(ncols))):
+            if i >= shape[0]:
+                break
+            axes[r, c].imshow(W[i, feature_map], cmap='gray',
+                              interpolation='nearest')
+
+
+def plot_conv_activity(layer, x, figsize=(6, 8)):
+    """Plot the acitivities of a specific layer. Only really makes
+    sense with layers that work 2D data (2D convolutional layers, 2D
+    pooling layers ...)
+    Parameters
+    ----------
+    layer : lasagne.layers.Layer
+    x : numpy.ndarray
+      Only takes one sample at a time, i.e. x.shape[0] == 1.
+    """
+    if x.shape[0] != 1:
+        raise ValueError("Only one sample can be plotted at a time.")
+    xs = T.tensor4('xs').astype(theano.config.floatX)
+    get_activity = theano.function([xs], layer.get_output(xs))
+    activity = get_activity(x)
+    shape = activity.shape
+    nrows = np.ceil(np.sqrt(shape[1])).astype(int)
+    ncols = nrows
+
+    figs, axes = plt.subplots(nrows + 1, ncols, figsize=figsize)
+    axes[0, ncols // 2].imshow(1 - x[0][0], cmap='gray',
+                               interpolation='nearest')
+    axes[0, ncols // 2].set_title('original')
+    for ax in axes.flatten():
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.axis('off')
+    for i, (r, c) in enumerate(product(range(nrows), range(ncols))):
+        if i >= shape[1]:
+            break
+        ndim = activity[0][i].ndim
+        if ndim != 2:
+            raise ValueError("Wrong number of dimensions, image data should "
+                             "have 2, instead got {}".format(ndim))
+        axes[r + 1, c].imshow(-activity[0][i], cmap='gray',
+                              interpolation='nearest')
+
+
+def plot_occlusion(net, X, y, square_length=7, figsize=(9, None)):
+    """Plot which parts of an image are particularly import for the
+    net to classify the image correctly.
+    See paper: Zeiler, Fergus 2013
+    Parameters
+    ----------
+    net : NeuralNet instance
+      The neural net to test.
+    X : np.array
+      The input data, should be of shape (b, c, x, y). Only makes
+      sense with image data.
+    y : np.array
+      The true values of the images.
+    square_length : int (default=7)
+      The length of the side of the square that occludes the image.
+    figsize : tuple (int, int)
+      Size of the figure.
+    """
+    if (X.ndim != 4):
+        raise ValueError("This function requires the input data to be of "
+                         "shape (b, c, x, y), instead got {}".format(X.shape))
+    num_images = X.shape[0]
+    if figsize[1] is None:
+        figsize = (figsize[0], num_images * figsize[0] / 3)
+    figs, axes = plt.subplots(num_images, 3, figsize=figsize)
+    for ax in axes.flatten():
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.axis('off')
+    for n in range(num_images):
+        heat_img = occlusion_heatmap(
+            net, X[n:n + 1, :, :, :], y[n], square_length
+        )
+
+        ax = axes if num_images == 1 else axes[n]
+        img = X[n, :, :, :].mean(0)
+        ax[0].imshow(-img, interpolation='nearest', cmap='gray')
+        ax[0].set_title('image')
+        ax[1].imshow(-heat_img, interpolation='nearest', cmap='Reds')
+        ax[1].set_title('critical parts')
+        ax[2].imshow(-img, interpolation='nearest', cmap='gray')
+        ax[2].imshow(-heat_img, interpolation='nearest', cmap='Reds',
+                     alpha=0.75)
+        ax[2].set_title('super-imposed')

--- a/nolearn/tests/conftest.py
+++ b/nolearn/tests/conftest.py
@@ -1,0 +1,4 @@
+def pytest_configure(config):
+    # Make matplotlib happy when running without an X display:
+    import matplotlib
+    matplotlib.use('Agg')

--- a/nolearn/tests/test_lasagne.py
+++ b/nolearn/tests/test_lasagne.py
@@ -339,3 +339,102 @@ class TestInitializeLayers:
         concat.assert_called_with([hidden1.return_value, hidden2.return_value],
                                   name='concat')
         output.assert_called_with(concat.return_value, name='output')
+
+
+def test_verbose_nn(mnist):
+    # Just check that no exception is thrown and that strings look
+    # right
+    from nolearn.lasagne import NeuralNet
+
+    X, y = mnist
+    X_train, y_train = X[:1000], y[:1000]
+    num_epochs = 7
+
+    nn = NeuralNet(
+        layers=[
+            ('input', InputLayer),
+            ('hidden1', DenseLayer),
+            ('dropout1', DropoutLayer),
+            ('hidden2', DenseLayer),
+            ('dropout2', DropoutLayer),
+            ('output', DenseLayer),
+            ],
+        input_shape=(None, 784),
+        output_num_units=10,
+        output_nonlinearity=softmax,
+
+        more_params=dict(
+            hidden1_num_units=512,
+            hidden2_num_units=512,
+            ),
+
+        update=nesterov_momentum,
+        update_learning_rate=0.01,
+        update_momentum=0.9,
+
+        max_epochs=num_epochs,
+        verbose=True,
+        )
+
+    nn.fit(X_train, y_train)
+    nn.predict_proba(X_train)
+    nn.predict(X_train)
+    nn.score(X_train, y_train)
+
+    assert nn.layer_infos_.replace(' ', '').startswith(u'|#|name|size|')
+
+
+def test_verbose_cnn(mnist):
+    # Just check that no exception is thrown and that strings look
+    # right
+    from nolearn.lasagne import NeuralNet
+    from lasagne.layers import Conv2DLayer
+    from lasagne.layers import MaxPool2DLayer
+
+    X, y = mnist
+    X_train, y_train = X[:100].reshape(-1, 1, 28, 28), y[:100]
+    X_train = X_train.reshape(-1, 1, 28, 28)
+    num_epochs = 3
+
+    nn = NeuralNet(
+        layers=[
+            ('input', InputLayer),
+            ('conv1', Conv2DLayer),
+            ('conv2', Conv2DLayer),
+            ('pool2', MaxPool2DLayer),
+            ('conv3', Conv2DLayer),
+            ('conv4', Conv2DLayer),
+            ('pool4', MaxPool2DLayer),
+            ('hidden1', DenseLayer),
+            ('output', DenseLayer),
+            ],
+        input_shape=(None, 1, 28, 28),
+        output_num_units=10,
+        output_nonlinearity=softmax,
+
+        more_params=dict(
+            conv1_filter_size=(5, 5), conv1_num_filters=16,
+            conv2_filter_size=(3, 3), conv2_num_filters=16,
+            pool2_ds=(3, 3),
+            conv3_filter_size=(3, 3), conv3_num_filters=16,
+            conv4_filter_size=(3, 3), conv4_num_filters=16,
+            pool4_ds=(2, 2),
+            hidden1_num_units=512,
+            ),
+
+        update=nesterov_momentum,
+        update_learning_rate=0.01,
+        update_momentum=0.9,
+
+        max_epochs=num_epochs,
+        verbose=3,
+        )
+
+    nn.fit(X_train, y_train)
+    nn.predict_proba(X_train)
+    nn.predict(X_train)
+    nn.score(X_train, y_train)
+
+    assert nn.layer_infos_.replace(' ', '').startswith(
+        u'namesizetotalcap.Y[%]cap.X[%]cov.Y[%]cov.X[%]filterYfilterXfieldY'
+        'fieldX')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 joblib==0.8.4
 scikit-learn==0.15.2
 Theano==0.7
+tabulate==0.7.5
 git+https://github.com/benanne/Lasagne.git@cd5e396f87#egg=Lasagne

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ except IOError:
 
 install_requires = [
     'joblib',
+    'matplotlib',
     'scikit-learn',
     ]
 


### PR DESCRIPTION
Layer infos about capacity and coverage à la Xudong Cao. For this, verbosity has to be > 1. If verbosity > 2, you get some additional information (real filter size and receptive field size).

For non-CNN, output should stay the same.

The layer infos are stored in the attribute 'layer_infos_' for later inspection.
