### PR TITLE
Feature: more detailed layer info

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -28,7 +28,7 @@ from .utils import _dict
 from .utils import _list
 from .utils import ansi
 from .utils import get_conv_infos
-from .utils import layers_have_conv2d
+from .utils import is_conv2d
 
 
 class BatchIterator(object):
@@ -457,8 +457,8 @@ class NeuralNet(BaseEstimator):
         print("## Layer information")
 
         layers = self.layers_.values()
-        contains_conv2d = layers_have_conv2d(layers)
-        if contains_conv2d and (self.verbose > 1):
+        layers_contain_conv2d = is_conv2d(layers)
+        if layers_contain_conv2d and (self.verbose > 1):
             self._print_layer_info_conv()
         else:
             self._print_layer_info_plain()

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from .._compat import pickle
 from collections import OrderedDict
-import functools
+from functools import reduce
 import itertools
 import operator
 from time import time
@@ -20,23 +20,15 @@ from sklearn.cross_validation import StratifiedKFold
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import mean_squared_error
 from sklearn.preprocessing import LabelEncoder
+from tabulate import tabulate
 import theano
 from theano import tensor as T
 
-
-class _list(list):
-    pass
-
-
-class _dict(dict):
-    def __contains__(self, key):
-        return True
-
-
-class ansi:
-    BLUE = '\033[94m'
-    GREEN = '\033[32m'
-    ENDC = '\033[0m'
+from .utils import _dict
+from .utils import _list
+from .utils import ansi
+from .utils import get_conv_infos
+from .utils import layers_have_conv2d
 
 
 class BatchIterator(object):
@@ -147,9 +139,6 @@ class NeuralNet(BaseEstimator):
             out = self._output_layer = self.initialize_layers()
         self._check_for_unused_kwargs()
 
-        if self.verbose:
-            self._print_layer_info(self.layers_.values())
-
         if self.X_tensor_type is None:
             types = {
                 2: T.matrix,
@@ -165,7 +154,11 @@ class NeuralNet(BaseEstimator):
             self.y_tensor_type,
             )
         self.train_iter_, self.eval_iter_, self.predict_iter_ = iter_funcs
+
         self._initialized = True
+
+        if self.verbose:
+            self._print_layer_info()
 
     def _get_params_for(self, name):
         collected = {}
@@ -454,14 +447,57 @@ class NeuralNet(BaseEstimator):
         self.__dict__.update(state)
         self.initialize()
 
-    def _print_layer_info(self, layers):
-        for layer in layers:
-            output_shape = layer.get_output_shape()
-            print("  {:<18}\t{:<20}\tproduces {:>7} outputs".format(
-                layer.name,
-                str(output_shape),
-                str(functools.reduce(operator.mul, output_shape[1:])),
-                ))
+    def _print_layer_info(self):
+        shapes = [param.get_value().shape for param in
+                  self.get_all_params() if param]
+        nparams = reduce(operator.add, [reduce(operator.mul, shape) for
+                                        shape in shapes])
+        print("# Neural Network with {} learnable parameters"
+              "\n".format(nparams))
+        print("## Layer information")
+
+        layers = self.layers_.values()
+        contains_conv2d = layers_have_conv2d(layers)
+        if contains_conv2d and (self.verbose > 1):
+            self._print_layer_info_conv()
+        else:
+            self._print_layer_info_plain()
+
+    def _print_layer_info_plain(self):
+        nums = list(range(len(self.layers)))
+        names = list(zip(*self.layers))[0]
+        output_shapes = ['x'.join(map(str, layer.get_output_shape()[1:]))
+                         for layer in self.layers_.values()]
+        table = OrderedDict([
+            ('#', nums),
+            ('name', names),
+            ('size', output_shapes),
+        ])
+        self.layer_infos_ = tabulate(table, 'keys', tablefmt='pipe')
+        print(self.layer_infos_)
+        print("")
+
+    def _print_layer_info_conv(self):
+        if self.verbose > 2:
+            detailed = True
+            tablefmt = 'simple'
+        else:
+            detailed = False
+            tablefmt = 'pipe'
+
+        self.layer_infos_ = get_conv_infos(self, detailed=detailed,
+                                           tablefmt=tablefmt)
+        print(self.layer_infos_)
+        print("\nExplanation")
+        print("    X, Y:    image dimensions")
+        print("    cap.:    learning capacity")
+        print("    cov.:    coverage of image")
+        print("    {}: capacity too low (<1/6)"
+              "".format("{}{}{}".format(ansi.MAGENTA, "magenta", ansi.ENDC)))
+        print("    {}:    image coverage too high (>100%)"
+              "".format("{}{}{}".format(ansi.CYAN, "cyan", ansi.ENDC)))
+        print("    {}:     capacity too low and coverage too high\n"
+              "".format("{}{}{}".format(ansi.RED, "red", ansi.ENDC)))
 
     def get_params(self, deep=True):
         params = super(NeuralNet, self).get_params(deep=deep)

--- a/nolearn/lasagne/utils.py
+++ b/nolearn/lasagne/utils.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 from itertools import product
 
 import numpy as np
@@ -52,3 +53,184 @@ def occlusion_heatmap(net, x, y, square_length=7):
     for i, j in product(*map(range, shape[2:])):
         heat_array[i, j] = probs[i * shape[0] + j, y.astype(int)]
     return heat_array
+=======
+import operator as op
+
+from lasagne.layers import Conv2DLayer
+from lasagne.layers import MaxPool2DLayer
+try:
+    from lasagne.layers.cuda_convnet import Conv2DCCLayer
+    from lasagne.layers.cuda_convnet import MaxPool2DCCLayer
+except ImportError:
+    Conv2DCCLayer = Conv2DLayer
+    MaxPool2DCCLayer = MaxPool2DLayer
+import numpy as np
+from tabulate import tabulate
+
+
+class _list(list):
+    pass
+
+
+class _dict(dict):
+    def __contains__(self, key):
+        return True
+
+
+class ansi:
+    BLUE = '\033[94m'
+    CYAN = '\033[36m'
+    GREEN = '\033[32m'
+    MAGENTA = '\033[35m'
+    RED = '\033[31m'
+    ENDC = '\033[0m'
+
+
+def layers_have_conv2d(layers):
+    try:
+        return any([isinstance(layer, (Conv2DLayer, Conv2DCCLayer))
+                    for layer in layers])
+    except TypeError:
+        return isinstance(layers, (Conv2DLayer, Conv2DCCLayer))
+
+
+def layers_have_maxpool2d(layers):
+    try:
+        return any([isinstance(layer, (MaxPool2DLayer, MaxPool2DCCLayer))
+                    for layer in layers])
+    except TypeError:
+        return isinstance(layers, (MaxPool2DLayer, MaxPool2DCCLayer))
+
+
+def get_real_filter(layers, img_size):
+    """Get the real filter sizes of each layer involved in
+    convoluation. See Xudong Cao:
+    https://www.kaggle.com/c/datasciencebowl/forums/t/13166/happy-lantern-festival-report-and-code
+
+    This does not yet take into consideration feature pooling,
+    padding, striding and similar gimmicks.
+
+    """
+    # imports here to prevent circular dependencies
+    real_filter = np.zeros((len(layers), 2))
+    conv_mode = True
+    first_conv_layer = True
+    expon = np.ones((1, 2))
+
+    for i, layer in enumerate(layers[1:]):
+        j = i + 1
+        if not conv_mode:
+            real_filter[j] = img_size
+            continue
+
+        if layers_have_conv2d(layer):
+            if not first_conv_layer:
+                new_filter = np.array(layer.filter_size) * expon
+                real_filter[j] = new_filter
+            else:
+                new_filter = np.array(layer.filter_size) * expon
+                real_filter[j] = new_filter
+                first_conv_layer = False
+        elif layers_have_maxpool2d(layer):
+            real_filter[j] = real_filter[i]
+            expon *= np.array(layer.ds)
+        else:
+            conv_mode = False
+            real_filter[j] = img_size
+
+    real_filter[0] = img_size
+    return real_filter
+
+
+def get_receptive_field(layers, img_size):
+    """Get the real filter sizes of each layer involved in
+    convoluation. See Xudong Cao:
+    https://www.kaggle.com/c/datasciencebowl/forums/t/13166/happy-lantern-festival-report-and-code
+
+    This does not yet take into consideration feature pooling,
+    padding, striding and similar gimmicks.
+
+    """
+    receptive_field = np.zeros((len(layers), 2))
+    conv_mode = True
+    first_conv_layer = True
+    expon = np.ones((1, 2))
+
+    for i, layer in enumerate(layers[1:]):
+        j = i + 1
+        if not conv_mode:
+            receptive_field[j] = img_size
+            continue
+
+        if layers_have_conv2d(layer):
+            if not first_conv_layer:
+                last_field = receptive_field[i]
+                new_field = (last_field + expon *
+                             (np.array(layer.filter_size) - 1))
+                receptive_field[j] = new_field
+            else:
+                receptive_field[j] = layer.filter_size
+                first_conv_layer = False
+        elif layers_have_maxpool2d(layer):
+            receptive_field[j] = receptive_field[i]
+            expon *= np.array(layer.ds)
+        else:
+            conv_mode = False
+            receptive_field[j] = img_size
+
+    receptive_field[0] = img_size
+    return receptive_field
+
+
+def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
+                   detailed=False):
+    CYA = ansi.CYAN
+    END = ansi.ENDC
+    MAG = ansi.MAGENTA
+    RED = ansi.RED
+
+    layers = net.layers_.values()
+    img_size = net.layers_['input'].get_output_shape()[2:]
+
+    header = ['name', 'size', 'total', 'cap. Y [%]', 'cap. X [%]',
+              'cov. Y [%]', 'cov. X [%]']
+    if detailed:
+        header += ['filter Y', 'filter X', 'field Y', 'field X']
+
+    shapes = [layer.get_output_shape()[1:] for layer in layers]
+    totals = [str(reduce(op.mul, shape)) for shape in shapes]
+    shapes = ['x'.join(map(str, shape)) for shape in shapes]
+    shapes = np.array(shapes).reshape(-1, 1)
+    totals = np.array(totals).reshape(-1, 1)
+
+    real_filters = get_real_filter(layers, img_size)
+    receptive_fields = get_receptive_field(layers, img_size)
+    capacity = 100. * real_filters / receptive_fields
+    capacity[np.negative(np.isfinite(capacity))] = 1
+    img_coverage = 100. * receptive_fields / img_size
+    layer_names = [layer.name if layer.name
+                   else str(layer).rsplit('.')[-1].split(' ')[0]
+                   for layer in layers]
+
+    colored_names = []
+    for name, (covy, covx), (capy, capx) in zip(
+            layer_names, img_coverage, capacity):
+        if (
+                ((covy > 100) or (covx > 100)) and
+                ((capy < min_capacity) or (capx < min_capacity))
+        ):
+            name = "{}{}{}".format(RED, name, END)
+        elif (covy > 100) or (covx > 100):
+            name = "{}{}{}".format(CYA, name, END)
+        elif (capy < min_capacity) or (capx < min_capacity):
+            name = "{}{}{}".format(MAG, name, END)
+        colored_names.append(name)
+    colored_names = np.array(colored_names).reshape(-1, 1)
+
+    table = np.hstack((colored_names, shapes, totals, capacity, img_coverage))
+    if detailed:
+        table = np.hstack((table, real_filters.astype(int),
+                           receptive_fields.astype(int)))
+
+    return tabulate(table, header, tablefmt=tablefmt, floatfmt='.2f')
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.

--- a/nolearn/lasagne/utils.py
+++ b/nolearn/lasagne/utils.py
@@ -1,4 +1,5 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 from itertools import product
 
 import numpy as np
@@ -55,7 +56,12 @@ def occlusion_heatmap(net, x, y, square_length=7):
     return heat_array
 =======
 import operator as op
+=======
+from itertools import product
+import operator
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
 
+from lasagne.layers import Layer
 from lasagne.layers import Conv2DLayer
 from lasagne.layers import MaxPool2DLayer
 try:
@@ -86,20 +92,18 @@ class ansi:
     ENDC = '\033[0m'
 
 
-def layers_have_conv2d(layers):
-    try:
-        return any([isinstance(layer, (Conv2DLayer, Conv2DCCLayer))
-                    for layer in layers])
-    except TypeError:
+def is_conv2d(layers):
+    if isinstance(layers, Layer):
         return isinstance(layers, (Conv2DLayer, Conv2DCCLayer))
+    return any([isinstance(layer, (Conv2DLayer, Conv2DCCLayer))
+                for layer in layers])
 
 
-def layers_have_maxpool2d(layers):
-    try:
-        return any([isinstance(layer, (MaxPool2DLayer, MaxPool2DCCLayer))
-                    for layer in layers])
-    except TypeError:
+def is_maxpool2d(layers):
+    if isinstance(layers, Layer):
         return isinstance(layers, (MaxPool2DLayer, MaxPool2DCCLayer))
+    return any([isinstance(layer, (MaxPool2DLayer, MaxPool2DCCLayer))
+                for layer in layers])
 
 
 def get_real_filter(layers, img_size):
@@ -123,7 +127,7 @@ def get_real_filter(layers, img_size):
             real_filter[j] = img_size
             continue
 
-        if layers_have_conv2d(layer):
+        if is_conv2d(layer):
             if not first_conv_layer:
                 new_filter = np.array(layer.filter_size) * expon
                 real_filter[j] = new_filter
@@ -131,7 +135,7 @@ def get_real_filter(layers, img_size):
                 new_filter = np.array(layer.filter_size) * expon
                 real_filter[j] = new_filter
                 first_conv_layer = False
-        elif layers_have_maxpool2d(layer):
+        elif is_maxpool2d(layer):
             real_filter[j] = real_filter[i]
             expon *= np.array(layer.ds)
         else:
@@ -162,7 +166,7 @@ def get_receptive_field(layers, img_size):
             receptive_field[j] = img_size
             continue
 
-        if layers_have_conv2d(layer):
+        if is_conv2d(layer):
             if not first_conv_layer:
                 last_field = receptive_field[i]
                 new_field = (last_field + expon *
@@ -171,7 +175,7 @@ def get_receptive_field(layers, img_size):
             else:
                 receptive_field[j] = layer.filter_size
                 first_conv_layer = False
-        elif layers_have_maxpool2d(layer):
+        elif is_maxpool2d(layer):
             receptive_field[j] = receptive_field[i]
             expon *= np.array(layer.ds)
         else:
@@ -198,7 +202,7 @@ def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
         header += ['filter Y', 'filter X', 'field Y', 'field X']
 
     shapes = [layer.get_output_shape()[1:] for layer in layers]
-    totals = [str(reduce(op.mul, shape)) for shape in shapes]
+    totals = [str(reduce(operator.mul, shape)) for shape in shapes]
     shapes = ['x'.join(map(str, shape)) for shape in shapes]
     shapes = np.array(shapes).reshape(-1, 1)
     totals = np.array(totals).reshape(-1, 1)
@@ -233,4 +237,58 @@ def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
                            receptive_fields.astype(int)))
 
     return tabulate(table, header, tablefmt=tablefmt, floatfmt='.2f')
+<<<<<<< HEAD
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
+=======
+
+
+def occlusion_heatmap(net, x, y, square_length=7):
+    """An occlusion test that checks an image for its critical parts.
+    In this test, a square part of the image is occluded (i.e. set to
+    0) and then the net is tested for its propensity to predict the
+    correct label. One should expect that this propensity shrinks of
+    critical parts of the image are occluded. If not, this indicates
+    overfitting.
+    Depending on the depth of the net and the size of the image, this
+    function may take awhile to finish, since one prediction for each
+    pixel of the image is made.
+    Currently, all color channels are occluded at the same time. Also,
+    this does not really work if images are randomly distorted.
+    See paper: Zeiler, Fergus 2013
+    Parameters
+    ----------
+    net : NeuralNet instance
+      The neural net to test.
+    x : np.array
+      The input data, should be of shape (1, c, x, y). Only makes
+      sense with image data.
+    y : np.array
+      The true value of the image.
+    square_length : int (default=7)
+      The length of the side of the square that occludes the image.
+    Results
+    -------
+    heat_array : np.array (with same size as image)
+      An 2D np.array that at each point (i, j) contains the predicted
+      probability of the correct class if the image is occluded by a
+      square with center (i, j).
+    """
+    if (x.ndim != 4) or x.shape[0] != 1:
+        raise ValueError("This function requires the input data to be of "
+                         "shape (1, c, x, y), instead got {}".format(x.shape))
+    img = x[0].copy()
+    shape = x.shape
+    heat_array = np.zeros(shape[2:])
+    pad = square_length // 2
+    x_occluded = np.zeros((shape[2] * shape[3], 1, shape[2], shape[3]),
+                          dtype=img.dtype)
+    for i, j in product(*map(range, shape[2:])):
+        x_padded = np.pad(img, ((0, 0), (pad, pad), (pad, pad)), 'constant')
+        x_padded[:, i:i + square_length, j:j + square_length] = 0.
+        x_occluded[i * shape[0] + j, 0] = x_padded[:, pad:-pad, pad:-pad]
+
+    probs = net.predict_proba(x_occluded)
+    for i, j in product(*map(range, shape[2:])):
+        heat_array[i, j] = probs[i * shape[0] + j, y.astype(int)]
+    return heat_array
 >>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.

--- a/nolearn/lasagne/utils.py
+++ b/nolearn/lasagne/utils.py
@@ -1,8 +1,17 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 from itertools import product
+from operator import mul
 
+from lasagne.layers import Layer
+from lasagne.layers import Conv2DLayer
+from lasagne.layers import MaxPool2DLayer
+try:
+    from lasagne.layers.cuda_convnet import Conv2DCCLayer
+    from lasagne.layers.cuda_convnet import MaxPool2DCCLayer
+except ImportError:
+    Conv2DCCLayer = Conv2DLayer
+    MaxPool2DCCLayer = MaxPool2DLayer
 import numpy as np
+from tabulate import tabulate
 
 
 def occlusion_heatmap(net, x, y, square_length=7):
@@ -54,24 +63,6 @@ def occlusion_heatmap(net, x, y, square_length=7):
     for i, j in product(*map(range, shape[2:])):
         heat_array[i, j] = probs[i * shape[0] + j, y.astype(int)]
     return heat_array
-=======
-import operator as op
-=======
-from itertools import product
-import operator
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
-
-from lasagne.layers import Layer
-from lasagne.layers import Conv2DLayer
-from lasagne.layers import MaxPool2DLayer
-try:
-    from lasagne.layers.cuda_convnet import Conv2DCCLayer
-    from lasagne.layers.cuda_convnet import MaxPool2DCCLayer
-except ImportError:
-    Conv2DCCLayer = Conv2DLayer
-    MaxPool2DCCLayer = MaxPool2DLayer
-import numpy as np
-from tabulate import tabulate
 
 
 class _list(list):
@@ -202,7 +193,7 @@ def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
         header += ['filter Y', 'filter X', 'field Y', 'field X']
 
     shapes = [layer.get_output_shape()[1:] for layer in layers]
-    totals = [str(reduce(operator.mul, shape)) for shape in shapes]
+    totals = [str(reduce(mul, shape)) for shape in shapes]
     shapes = ['x'.join(map(str, shape)) for shape in shapes]
     shapes = np.array(shapes).reshape(-1, 1)
     totals = np.array(totals).reshape(-1, 1)
@@ -237,58 +228,3 @@ def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
                            receptive_fields.astype(int)))
 
     return tabulate(table, header, tablefmt=tablefmt, floatfmt='.2f')
-<<<<<<< HEAD
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
-=======
-
-
-def occlusion_heatmap(net, x, y, square_length=7):
-    """An occlusion test that checks an image for its critical parts.
-    In this test, a square part of the image is occluded (i.e. set to
-    0) and then the net is tested for its propensity to predict the
-    correct label. One should expect that this propensity shrinks of
-    critical parts of the image are occluded. If not, this indicates
-    overfitting.
-    Depending on the depth of the net and the size of the image, this
-    function may take awhile to finish, since one prediction for each
-    pixel of the image is made.
-    Currently, all color channels are occluded at the same time. Also,
-    this does not really work if images are randomly distorted.
-    See paper: Zeiler, Fergus 2013
-    Parameters
-    ----------
-    net : NeuralNet instance
-      The neural net to test.
-    x : np.array
-      The input data, should be of shape (1, c, x, y). Only makes
-      sense with image data.
-    y : np.array
-      The true value of the image.
-    square_length : int (default=7)
-      The length of the side of the square that occludes the image.
-    Results
-    -------
-    heat_array : np.array (with same size as image)
-      An 2D np.array that at each point (i, j) contains the predicted
-      probability of the correct class if the image is occluded by a
-      square with center (i, j).
-    """
-    if (x.ndim != 4) or x.shape[0] != 1:
-        raise ValueError("This function requires the input data to be of "
-                         "shape (1, c, x, y), instead got {}".format(x.shape))
-    img = x[0].copy()
-    shape = x.shape
-    heat_array = np.zeros(shape[2:])
-    pad = square_length // 2
-    x_occluded = np.zeros((shape[2] * shape[3], 1, shape[2], shape[3]),
-                          dtype=img.dtype)
-    for i, j in product(*map(range, shape[2:])):
-        x_padded = np.pad(img, ((0, 0), (pad, pad), (pad, pad)), 'constant')
-        x_padded[:, i:i + square_length, j:j + square_length] = 0.
-        x_occluded[i * shape[0] + j, 0] = x_padded[:, pad:-pad, pad:-pad]
-
-    probs = net.predict_proba(x_occluded)
-    for i, j in product(*map(range, shape[2:])):
-        heat_array[i, j] = probs[i * shape[0] + j, y.astype(int)]
-    return heat_array
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.

--- a/nolearn/tests/test_lasagne.py
+++ b/nolearn/tests/test_lasagne.py
@@ -332,13 +332,13 @@ class TestInitializeLayers:
             Mock(__name__='MockLayer') for i in range(4)]
         nn = NeuralNet(
             layers=[
-                (input, {'shape': (10, 10), 'name': 'input'}),
-                (hidden1, {'some': 'param', 'another': 'param'}),
-                (hidden2, {}),
-                (output, {'name': 'output'}),
+                ('input', input),
+                ('hidden1', hidden1),
+                ('hidden2', hidden2),
+                ('output', output),
                 ],
             input_shape=(10, 10),
-            mock1_some='iwin',
+            hidden1_some='param',
             )
         out = nn.initialize_layers(nn.layers)
 
@@ -347,13 +347,12 @@ class TestInitializeLayers:
         nn.layers_['input'] is input.return_value
 
         hidden1.assert_called_with(
-            incoming=input.return_value, name='mock1',
-            some='iwin', another='param')
-        nn.layers_['mock1'] is hidden1.return_value
+            incoming=input.return_value, name='hidden1', some='param')
+        nn.layers_['hidden1'] is hidden1.return_value
 
         hidden2.assert_called_with(
-            incoming=hidden1.return_value, name='mock2')
-        nn.layers_['mock2'] is hidden2.return_value
+            incoming=hidden1.return_value, name='hidden2')
+        nn.layers_['hidden2'] is hidden2.return_value
 
         output.assert_called_with(
             incoming=hidden2.return_value, name='output')

--- a/nolearn/tests/test_lasagne.py
+++ b/nolearn/tests/test_lasagne.py
@@ -268,11 +268,7 @@ class TestTrainTestSplit:
 class TestCheckForUnusedKwargs:
     def test_okay(self, NeuralNet):
         net = NeuralNet(
-<<<<<<< HEAD
             layers=[('input', Mock), ('mylayer', Mock)],
-=======
-            layers=[('input', Mock()), ('mylayer', Mock())],
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
             input_shape=(10, 10),
             mylayer_hey='hey',
             update_foo=1,
@@ -283,11 +279,7 @@ class TestCheckForUnusedKwargs:
 
     def test_unused(self, NeuralNet):
         net = NeuralNet(
-<<<<<<< HEAD
             layers=[('input', Mock), ('mylayer', Mock)],
-=======
-            layers=[('input', Mock()), ('mylayer', Mock())],
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
             input_shape=(10, 10),
             mylayer_hey='hey',
             yourlayer_ho='ho',
@@ -368,37 +360,6 @@ class TestInitializeLayers:
 
         assert out is nn.layers_['output']
 
-    def test_initialization_legacy(self, NeuralNet):
-        input, hidden1, hidden2, output = Mock(), Mock(), Mock(), Mock()
-        nn = NeuralNet(
-            layers=[
-                ('input', input),
-                ('hidden1', hidden1),
-                ('hidden2', hidden2),
-                ('output', output),
-                ],
-            input_shape=(10, 10),
-            hidden1_some='param',
-            )
-        out = nn.initialize_layers(nn.layers)
-
-        input.assert_called_with(
-            name='input', shape=(10, 10))
-        nn.layers_['input'] is input.return_value
-
-        hidden1.assert_called_with(
-            incoming=input.return_value, name='hidden1', some='param')
-        nn.layers_['hidden1'] is hidden1.return_value
-
-        hidden2.assert_called_with(
-            incoming=hidden1.return_value, name='hidden2')
-        nn.layers_['hidden2'] is hidden2.return_value
-
-        output.assert_called_with(
-            incoming=hidden2.return_value, name='output')
-
-        assert out is nn.layers_['output']
-
     def test_diamond(self, NeuralNet):
         input, hidden1, hidden2, concat, output = [
             Mock(__name__='MockLayer') for i in range(5)]
@@ -417,10 +378,6 @@ class TestInitializeLayers:
         nn.initialize_layers(nn.layers)
 
         input.assert_called_with(name='input', shape=(10, 10))
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
         hidden1.assert_called_with(incoming=input.return_value, name='hidden1')
         hidden2.assert_called_with(incoming=input.return_value, name='hidden2')
         concat.assert_called_with(
@@ -428,155 +385,6 @@ class TestInitializeLayers:
             name='concat'
             )
         output.assert_called_with(incoming=concat.return_value, name='output')
-<<<<<<< HEAD
-
-
-def test_visualize_functions_with_cnn(mnist):
-    # this test simply tests that no exception is raised when using
-    # the plotting functions
-
-    from nolearn.lasagne import NeuralNet
-    from nolearn.lasagne.visualize import plot_conv_activity
-    from nolearn.lasagne.visualize import plot_conv_weights
-    from nolearn.lasagne.visualize import plot_loss
-    from nolearn.lasagne.visualize import plot_occlusion
-=======
-        hidden1.assert_called_with(input.return_value, name='hidden1')
-        hidden2.assert_called_with(input.return_value, name='hidden2')
-        concat.assert_called_with([hidden1.return_value, hidden2.return_value],
-                                  name='concat')
-        output.assert_called_with(concat.return_value, name='output')
-=======
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
-
-
-def test_verbose_nn(mnist):
-    # Just check that no exception is thrown and that strings look
-    # right
-    from nolearn.lasagne import NeuralNet
-
-    X, y = mnist
-    X_train, y_train = X[:1000], y[:1000]
-    num_epochs = 7
-
-    nn = NeuralNet(
-        layers=[
-            ('input', InputLayer),
-            ('hidden1', DenseLayer),
-            ('dropout1', DropoutLayer),
-            ('hidden2', DenseLayer),
-            ('dropout2', DropoutLayer),
-            ('output', DenseLayer),
-            ],
-        input_shape=(None, 784),
-        output_num_units=10,
-        output_nonlinearity=softmax,
-
-        more_params=dict(
-            hidden1_num_units=512,
-            hidden2_num_units=512,
-            ),
-
-        update=nesterov_momentum,
-        update_learning_rate=0.01,
-        update_momentum=0.9,
-
-        max_epochs=num_epochs,
-        verbose=True,
-        )
-
-    nn.fit(X_train, y_train)
-    nn.predict_proba(X_train)
-    nn.predict(X_train)
-    nn.score(X_train, y_train)
-
-    assert nn.layer_infos_.replace(' ', '').startswith(u'|#|name|size|')
-
-
-def test_verbose_cnn(mnist):
-    # Just check that no exception is thrown and that strings look
-    # right
-    from nolearn.lasagne import NeuralNet
-    from lasagne.layers import Conv2DLayer
-    from lasagne.layers import MaxPool2DLayer
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
-
-    X, y = mnist
-    X_train, y_train = X[:100].reshape(-1, 1, 28, 28), y[:100]
-    X_train = X_train.reshape(-1, 1, 28, 28)
-    num_epochs = 3
-
-    nn = NeuralNet(
-        layers=[
-            ('input', InputLayer),
-            ('conv1', Conv2DLayer),
-            ('conv2', Conv2DLayer),
-            ('pool2', MaxPool2DLayer),
-            ('conv3', Conv2DLayer),
-            ('conv4', Conv2DLayer),
-            ('pool4', MaxPool2DLayer),
-            ('hidden1', DenseLayer),
-            ('output', DenseLayer),
-            ],
-        input_shape=(None, 1, 28, 28),
-        output_num_units=10,
-        output_nonlinearity=softmax,
-
-        more_params=dict(
-            conv1_filter_size=(5, 5), conv1_num_filters=16,
-            conv2_filter_size=(3, 3), conv2_num_filters=16,
-            pool2_ds=(3, 3),
-            conv3_filter_size=(3, 3), conv3_num_filters=16,
-            conv4_filter_size=(3, 3), conv4_num_filters=16,
-            pool4_ds=(2, 2),
-<<<<<<< HEAD
-<<<<<<< HEAD
-            hidden1_num_units=16,
-=======
-            hidden1_num_units=512,
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
-=======
-            hidden1_num_units=16,
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
-            ),
-
-        update=nesterov_momentum,
-        update_learning_rate=0.01,
-        update_momentum=0.9,
-
-        max_epochs=num_epochs,
-<<<<<<< HEAD
-        )
-
-    nn.fit(X_train, y_train)
-
-    plot_loss(nn)
-    plot_conv_weights(nn.layers_['conv1'])
-    plot_conv_weights(nn.layers_['conv2'], figsize=(1, 2))
-    plot_conv_activity(nn.layers_['conv3'], X_train[:1])
-    plot_conv_activity(nn.layers_['conv4'], X_train[10:11], figsize=(3, 4))
-    plot_occlusion(nn, X_train[:1], y_train[:1])
-    plot_occlusion(nn, X_train[2:4], y_train[2:4], square_length=3,
-                   figsize=(5, 5))
-
-    # clear figures from memory
-    plt.clf()
-    plt.cla()
-=======
-        verbose=3,
-        )
-
-    nn.fit(X_train, y_train)
-    nn.predict_proba(X_train)
-    nn.predict(X_train)
-    nn.score(X_train, y_train)
-
-    assert nn.layer_infos_.replace(' ', '').startswith(
-        u'namesizetotalcap.Y[%]cap.X[%]cov.Y[%]cov.X[%]filterYfilterXfieldY'
-        'fieldX')
-<<<<<<< HEAD
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
-=======
 
 
 def test_visualize_functions_with_cnn(mnist):
@@ -641,4 +449,3 @@ def test_visualize_functions_with_cnn(mnist):
     # clear figures from memory
     plt.clf()
     plt.cla()
->>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.

--- a/nolearn/tests/test_lasagne.py
+++ b/nolearn/tests/test_lasagne.py
@@ -377,6 +377,7 @@ class TestInitializeLayers:
         nn.initialize_layers(nn.layers)
 
         input.assert_called_with(name='input', shape=(10, 10))
+<<<<<<< HEAD
         hidden1.assert_called_with(incoming=input.return_value, name='hidden1')
         hidden2.assert_called_with(incoming=input.return_value, name='hidden2')
         concat.assert_called_with(
@@ -395,6 +396,64 @@ def test_visualize_functions_with_cnn(mnist):
     from nolearn.lasagne.visualize import plot_conv_weights
     from nolearn.lasagne.visualize import plot_loss
     from nolearn.lasagne.visualize import plot_occlusion
+=======
+        hidden1.assert_called_with(input.return_value, name='hidden1')
+        hidden2.assert_called_with(input.return_value, name='hidden2')
+        concat.assert_called_with([hidden1.return_value, hidden2.return_value],
+                                  name='concat')
+        output.assert_called_with(concat.return_value, name='output')
+
+
+def test_verbose_nn(mnist):
+    # Just check that no exception is thrown and that strings look
+    # right
+    from nolearn.lasagne import NeuralNet
+
+    X, y = mnist
+    X_train, y_train = X[:1000], y[:1000]
+    num_epochs = 7
+
+    nn = NeuralNet(
+        layers=[
+            ('input', InputLayer),
+            ('hidden1', DenseLayer),
+            ('dropout1', DropoutLayer),
+            ('hidden2', DenseLayer),
+            ('dropout2', DropoutLayer),
+            ('output', DenseLayer),
+            ],
+        input_shape=(None, 784),
+        output_num_units=10,
+        output_nonlinearity=softmax,
+
+        more_params=dict(
+            hidden1_num_units=512,
+            hidden2_num_units=512,
+            ),
+
+        update=nesterov_momentum,
+        update_learning_rate=0.01,
+        update_momentum=0.9,
+
+        max_epochs=num_epochs,
+        verbose=True,
+        )
+
+    nn.fit(X_train, y_train)
+    nn.predict_proba(X_train)
+    nn.predict(X_train)
+    nn.score(X_train, y_train)
+
+    assert nn.layer_infos_.replace(' ', '').startswith(u'|#|name|size|')
+
+
+def test_verbose_cnn(mnist):
+    # Just check that no exception is thrown and that strings look
+    # right
+    from nolearn.lasagne import NeuralNet
+    from lasagne.layers import Conv2DLayer
+    from lasagne.layers import MaxPool2DLayer
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
 
     X, y = mnist
     X_train, y_train = X[:100].reshape(-1, 1, 28, 28), y[:100]
@@ -424,7 +483,11 @@ def test_visualize_functions_with_cnn(mnist):
             conv3_filter_size=(3, 3), conv3_num_filters=16,
             conv4_filter_size=(3, 3), conv4_num_filters=16,
             pool4_ds=(2, 2),
+<<<<<<< HEAD
             hidden1_num_units=16,
+=======
+            hidden1_num_units=512,
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
             ),
 
         update=nesterov_momentum,
@@ -432,6 +495,7 @@ def test_visualize_functions_with_cnn(mnist):
         update_momentum=0.9,
 
         max_epochs=num_epochs,
+<<<<<<< HEAD
         )
 
     nn.fit(X_train, y_train)
@@ -448,3 +512,16 @@ def test_visualize_functions_with_cnn(mnist):
     # clear figures from memory
     plt.clf()
     plt.cla()
+=======
+        verbose=3,
+        )
+
+    nn.fit(X_train, y_train)
+    nn.predict_proba(X_train)
+    nn.predict(X_train)
+    nn.score(X_train, y_train)
+
+    assert nn.layer_infos_.replace(' ', '').startswith(
+        u'namesizetotalcap.Y[%]cap.X[%]cov.Y[%]cov.X[%]filterYfilterXfieldY'
+        'fieldX')
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.

--- a/nolearn/tests/test_lasagne.py
+++ b/nolearn/tests/test_lasagne.py
@@ -268,7 +268,11 @@ class TestTrainTestSplit:
 class TestCheckForUnusedKwargs:
     def test_okay(self, NeuralNet):
         net = NeuralNet(
+<<<<<<< HEAD
             layers=[('input', Mock), ('mylayer', Mock)],
+=======
+            layers=[('input', Mock()), ('mylayer', Mock())],
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
             input_shape=(10, 10),
             mylayer_hey='hey',
             update_foo=1,
@@ -279,7 +283,11 @@ class TestCheckForUnusedKwargs:
 
     def test_unused(self, NeuralNet):
         net = NeuralNet(
+<<<<<<< HEAD
             layers=[('input', Mock), ('mylayer', Mock)],
+=======
+            layers=[('input', Mock()), ('mylayer', Mock())],
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
             input_shape=(10, 10),
             mylayer_hey='hey',
             yourlayer_ho='ho',
@@ -332,6 +340,38 @@ class TestInitializeLayers:
             Mock(__name__='MockLayer') for i in range(4)]
         nn = NeuralNet(
             layers=[
+                (input, {'shape': (10, 10), 'name': 'input'}),
+                (hidden1, {'some': 'param', 'another': 'param'}),
+                (hidden2, {}),
+                (output, {'name': 'output'}),
+                ],
+            input_shape=(10, 10),
+            mock1_some='iwin',
+            )
+        out = nn.initialize_layers(nn.layers)
+
+        input.assert_called_with(
+            name='input', shape=(10, 10))
+        nn.layers_['input'] is input.return_value
+
+        hidden1.assert_called_with(
+            incoming=input.return_value, name='mock1',
+            some='iwin', another='param')
+        nn.layers_['mock1'] is hidden1.return_value
+
+        hidden2.assert_called_with(
+            incoming=hidden1.return_value, name='mock2')
+        nn.layers_['mock2'] is hidden2.return_value
+
+        output.assert_called_with(
+            incoming=hidden2.return_value, name='output')
+
+        assert out is nn.layers_['output']
+
+    def test_initialization_legacy(self, NeuralNet):
+        input, hidden1, hidden2, output = Mock(), Mock(), Mock(), Mock()
+        nn = NeuralNet(
+            layers=[
                 ('input', input),
                 ('hidden1', hidden1),
                 ('hidden2', hidden2),
@@ -378,6 +418,9 @@ class TestInitializeLayers:
 
         input.assert_called_with(name='input', shape=(10, 10))
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
         hidden1.assert_called_with(incoming=input.return_value, name='hidden1')
         hidden2.assert_called_with(incoming=input.return_value, name='hidden2')
         concat.assert_called_with(
@@ -385,6 +428,7 @@ class TestInitializeLayers:
             name='concat'
             )
         output.assert_called_with(incoming=concat.return_value, name='output')
+<<<<<<< HEAD
 
 
 def test_visualize_functions_with_cnn(mnist):
@@ -402,6 +446,8 @@ def test_visualize_functions_with_cnn(mnist):
         concat.assert_called_with([hidden1.return_value, hidden2.return_value],
                                   name='concat')
         output.assert_called_with(concat.return_value, name='output')
+=======
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
 
 
 def test_verbose_nn(mnist):
@@ -484,9 +530,13 @@ def test_verbose_cnn(mnist):
             conv4_filter_size=(3, 3), conv4_num_filters=16,
             pool4_ds=(2, 2),
 <<<<<<< HEAD
+<<<<<<< HEAD
             hidden1_num_units=16,
 =======
             hidden1_num_units=512,
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
+=======
+            hidden1_num_units=16,
 >>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
             ),
 
@@ -524,4 +574,71 @@ def test_verbose_cnn(mnist):
     assert nn.layer_infos_.replace(' ', '').startswith(
         u'namesizetotalcap.Y[%]cap.X[%]cov.Y[%]cov.X[%]filterYfilterXfieldY'
         'fieldX')
+<<<<<<< HEAD
+>>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.
+=======
+
+
+def test_visualize_functions_with_cnn(mnist):
+    # this test simply tests that no exception is raised when using
+    # the plotting functions
+
+    from nolearn.lasagne import NeuralNet
+    from nolearn.lasagne.visualize import plot_conv_activity
+    from nolearn.lasagne.visualize import plot_conv_weights
+    from nolearn.lasagne.visualize import plot_loss
+    from nolearn.lasagne.visualize import plot_occlusion
+
+    X, y = mnist
+    X_train, y_train = X[:100].reshape(-1, 1, 28, 28), y[:100]
+    X_train = X_train.reshape(-1, 1, 28, 28)
+    num_epochs = 3
+
+    nn = NeuralNet(
+        layers=[
+            ('input', InputLayer),
+            ('conv1', Conv2DLayer),
+            ('conv2', Conv2DLayer),
+            ('pool2', MaxPool2DLayer),
+            ('conv3', Conv2DLayer),
+            ('conv4', Conv2DLayer),
+            ('pool4', MaxPool2DLayer),
+            ('hidden1', DenseLayer),
+            ('output', DenseLayer),
+            ],
+        input_shape=(None, 1, 28, 28),
+        output_num_units=10,
+        output_nonlinearity=softmax,
+
+        more_params=dict(
+            conv1_filter_size=(5, 5), conv1_num_filters=16,
+            conv2_filter_size=(3, 3), conv2_num_filters=16,
+            pool2_ds=(3, 3),
+            conv3_filter_size=(3, 3), conv3_num_filters=16,
+            conv4_filter_size=(3, 3), conv4_num_filters=16,
+            pool4_ds=(2, 2),
+            hidden1_num_units=16,
+            ),
+
+        update=nesterov_momentum,
+        update_learning_rate=0.01,
+        update_momentum=0.9,
+
+        max_epochs=num_epochs,
+        )
+
+    nn.fit(X_train, y_train)
+
+    plot_loss(nn)
+    plot_conv_weights(nn.layers_['conv1'])
+    plot_conv_weights(nn.layers_['conv2'], figsize=(1, 2))
+    plot_conv_activity(nn.layers_['conv3'], X_train[:1])
+    plot_conv_activity(nn.layers_['conv4'], X_train[10:11], figsize=(3, 4))
+    plot_occlusion(nn, X_train[:1], y_train[:1])
+    plot_occlusion(nn, X_train[2:4], y_train[2:4], square_length=3,
+                   figsize=(5, 5))
+
+    # clear figures from memory
+    plt.clf()
+    plt.cla()
 >>>>>>> More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use.  New dependency: tabulate.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 joblib==0.8.4
 scikit-learn==0.15.2
 Theano==0.7
+tabulate==0.7.5
 git+https://github.com/benanne/Lasagne.git@cd5e396f87#egg=Lasagne


### PR DESCRIPTION
More detailed architecture information is now printed for convolutional nets (see Xudong Cao); layer infos are saved in layer_infos_ attribute for potential later use. The level of detail now depends on verbosity, use verbose>1 for more detailed layer information.

Moved some lines from base to utils.

New dependency: tabulate.