### PR TITLE
Added on_training_started feature. 

### DIFF
--- a/nolearn/lasagne/__init__.py
+++ b/nolearn/lasagne/__init__.py
@@ -1,4 +1,5 @@
 from .handlers import (
+    PrintLayerInfo,
     PrintLog,
     SaveWeights,
     )

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -325,7 +325,7 @@ class NeuralNet(BaseEstimator):
             self.train_history_ else np.inf
             )
         for func in on_training_started:
-            func(self)
+            func(self, self.train_history_)
 
         num_epochs_past = len(self.train_history_)
 

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -26,6 +26,7 @@ import theano
 from theano import tensor as T
 
 from . import PrintLog
+from . import PrintLayerInfo
 
 
 class _list(list):
@@ -81,6 +82,7 @@ class NeuralNet(BaseEstimator):
         y_tensor_type=None,
         use_label_encoder=False,
         on_epoch_finished=None,
+        on_training_started=None,
         on_training_finished=None,
         more_params=None,
         verbose=0,
@@ -111,11 +113,13 @@ class NeuralNet(BaseEstimator):
         self.y_tensor_type = y_tensor_type
         self.use_label_encoder = use_label_encoder
         self.on_epoch_finished = on_epoch_finished or []
+        self.on_training_started = on_training_started or []
         self.on_training_finished = on_training_finished or []
         self.more_params = more_params or {}
         self.verbose = verbose
         if self.verbose:
             self.on_epoch_finished.append(PrintLog())
+            self.on_training_started.append(PrintLayerInfo())
 
         for key in kwargs.keys():
             assert not hasattr(self, key)
@@ -303,6 +307,10 @@ class NeuralNet(BaseEstimator):
         if not isinstance(on_epoch_finished, (list, tuple)):
             on_epoch_finished = [on_epoch_finished]
 
+        on_training_started = self.on_training_started
+        if not isinstance(on_training_started, (list, tuple)):
+            on_training_started = [on_training_started]
+
         on_training_finished = self.on_training_finished
         if not isinstance(on_training_finished, (list, tuple)):
             on_training_finished = [on_training_finished]
@@ -316,7 +324,9 @@ class NeuralNet(BaseEstimator):
             min([row['train_loss'] for row in self.train_history_]) if
             self.train_history_ else np.inf
             )
-        first_iteration = True
+        for func in on_training_started:
+            func(self)
+
         num_epochs_past = len(self.train_history_)
 
         while epoch < self.max_epochs:

--- a/nolearn/lasagne/handlers.py
+++ b/nolearn/lasagne/handlers.py
@@ -103,7 +103,7 @@ class PrintLayerInfo:
         print("## Layer information")
         print("")
 
-        layers_contain_conv2d = is_conv2d(nn.layers_.values())
+        layers_contain_conv2d = is_conv2d(list(nn.layers_.values()))
         if not layers_contain_conv2d or (nn.verbose < 2):
             layer_info = self._get_layer_info_plain(nn)
             legend = None
@@ -143,13 +143,11 @@ class PrintLayerInfo:
     def _get_layer_info_conv(nn):
         if nn.verbose > 2:
             detailed = True
-            tablefmt = 'simple'
         else:
             detailed = False
-            tablefmt = 'pipe'
 
         layer_infos = get_conv_infos(nn, detailed=detailed,
-                                     tablefmt=tablefmt)
+                                     tablefmt='pipe')
 
         mag = "{}{}{}".format(ansi.MAGENTA, "magenta", ansi.ENDC)
         cya = "{}{}{}".format(ansi.CYAN, "cyan", ansi.ENDC)

--- a/nolearn/lasagne/handlers.py
+++ b/nolearn/lasagne/handlers.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from datetime import datetime
+from functools import reduce
 import operator
 
 from tabulate import tabulate
@@ -96,7 +97,7 @@ class PrintLayerInfo:
     def __init__(self):
         pass
 
-    def __call__(self, nn):
+    def __call__(self, nn, train_history):
         message = self._get_greeting(nn)
         print(message)
         print("## Layer information")

--- a/nolearn/lasagne/util.py
+++ b/nolearn/lasagne/util.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from operator import mul
 
 from lasagne.layers import Layer

--- a/nolearn/lasagne/util.py
+++ b/nolearn/lasagne/util.py
@@ -131,7 +131,7 @@ def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
 
     layers = net.layers_.values()
     # assume that first layer is input layer
-    img_size = net.layers_.values()[0].get_output_shape()[2:]
+    img_size = list(net.layers_.values())[0].get_output_shape()[2:]
 
     header = ['name', 'size', 'total', 'cap. Y [%]', 'cap. X [%]',
               'cov. Y [%]', 'cov. X [%]']

--- a/nolearn/lasagne/util.py
+++ b/nolearn/lasagne/util.py
@@ -1,0 +1,176 @@
+from operator import mul
+
+from lasagne.layers import Layer
+from lasagne.layers import Conv2DLayer
+from lasagne.layers import MaxPool2DLayer
+import numpy as np
+from tabulate import tabulate
+
+convlayers = [Conv2DLayer]
+maxpoollayers = [MaxPool2DLayer]
+try:
+    from lasagne.layers.cuda_convnet import Conv2DCCLayer
+    from lasagne.layers.cuda_convnet import MaxPool2DCCLayer
+    convlayers.append(Conv2DCCLayer)
+    maxpoollayers.append(MaxPool2DCCLayer)
+except ImportError:
+    pass
+try:
+    from lasagne.layers.dnn import Conv2DDNNLayer
+    from lasagne.layers.dnn import MaxPool2DDNNLayer
+    convlayers.append(Conv2DDNNLayer)
+    maxpoollayers.append(MaxPool2DDNNLayer)
+except ImportError:
+    pass
+
+
+class ansi:
+    BLUE = '\033[94m'
+    CYAN = '\033[36m'
+    GREEN = '\033[32m'
+    MAGENTA = '\033[35m'
+    RED = '\033[31m'
+    ENDC = '\033[0m'
+
+
+def is_conv2d(layers):
+    if isinstance(layers, Layer):
+        return isinstance(layers, tuple(convlayers))
+    return any([isinstance(layer, tuple(convlayers))
+                for layer in layers])
+
+
+def is_maxpool2d(layers):
+    if isinstance(layers, Layer):
+        return isinstance(layers, tuple(maxpoollayers))
+    return any([isinstance(layer, tuple(maxpoollayers))
+                for layer in layers])
+
+
+def get_real_filter(layers, img_size):
+    """Get the real filter sizes of each layer involved in
+    convoluation. See Xudong Cao:
+    https://www.kaggle.com/c/datasciencebowl/forums/t/13166/happy-lantern-festival-report-and-code
+    This does not yet take into consideration feature pooling,
+    padding, striding and similar gimmicks.
+    """
+    real_filter = np.zeros((len(layers), 2))
+    conv_mode = True
+    first_conv_layer = True
+    expon = np.ones((1, 2))
+
+    for i, layer in enumerate(layers[1:]):
+        j = i + 1
+        if not conv_mode:
+            real_filter[j] = img_size
+            continue
+
+        if is_conv2d(layer):
+            if not first_conv_layer:
+                new_filter = np.array(layer.filter_size) * expon
+                real_filter[j] = new_filter
+            else:
+                new_filter = np.array(layer.filter_size) * expon
+                real_filter[j] = new_filter
+                first_conv_layer = False
+        elif is_maxpool2d(layer):
+            real_filter[j] = real_filter[i]
+            expon *= np.array(layer.pool_size)
+        else:
+            conv_mode = False
+            real_filter[j] = img_size
+
+    real_filter[0] = img_size
+    return real_filter
+
+
+def get_receptive_field(layers, img_size):
+    """Get the real filter sizes of each layer involved in
+    convoluation. See Xudong Cao:
+    https://www.kaggle.com/c/datasciencebowl/forums/t/13166/happy-lantern-festival-report-and-code
+    This does not yet take into consideration feature pooling,
+    padding, striding and similar gimmicks.
+    """
+    receptive_field = np.zeros((len(layers), 2))
+    conv_mode = True
+    first_conv_layer = True
+    expon = np.ones((1, 2))
+
+    for i, layer in enumerate(layers[1:]):
+        j = i + 1
+        if not conv_mode:
+            receptive_field[j] = img_size
+            continue
+
+        if is_conv2d(layer):
+            if not first_conv_layer:
+                last_field = receptive_field[i]
+                new_field = (last_field + expon *
+                             (np.array(layer.filter_size) - 1))
+                receptive_field[j] = new_field
+            else:
+                receptive_field[j] = layer.filter_size
+                first_conv_layer = False
+        elif is_maxpool2d(layer):
+            receptive_field[j] = receptive_field[i]
+            expon *= np.array(layer.pool_size)
+        else:
+            conv_mode = False
+            receptive_field[j] = img_size
+
+    receptive_field[0] = img_size
+    return receptive_field
+
+
+def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
+                   detailed=False):
+    CYA = ansi.CYAN
+    END = ansi.ENDC
+    MAG = ansi.MAGENTA
+    RED = ansi.RED
+
+    layers = net.layers_.values()
+    # assume that first layer is input layer
+    img_size = net.layers_.values()[0].get_output_shape()[2:]
+
+    header = ['name', 'size', 'total', 'cap. Y [%]', 'cap. X [%]',
+              'cov. Y [%]', 'cov. X [%]']
+    if detailed:
+        header += ['filter Y', 'filter X', 'field Y', 'field X']
+
+    shapes = [layer.get_output_shape()[1:] for layer in layers]
+    totals = [str(reduce(mul, shape)) for shape in shapes]
+    shapes = ['x'.join(map(str, shape)) for shape in shapes]
+    shapes = np.array(shapes).reshape(-1, 1)
+    totals = np.array(totals).reshape(-1, 1)
+
+    real_filters = get_real_filter(layers, img_size)
+    receptive_fields = get_receptive_field(layers, img_size)
+    capacity = 100. * real_filters / receptive_fields
+    capacity[np.negative(np.isfinite(capacity))] = 1
+    img_coverage = 100. * receptive_fields / img_size
+    layer_names = [layer.name if layer.name
+                   else str(layer).rsplit('.')[-1].split(' ')[0]
+                   for layer in layers]
+
+    colored_names = []
+    for name, (covy, covx), (capy, capx) in zip(
+            layer_names, img_coverage, capacity):
+        if (
+                ((covy > 100) or (covx > 100)) and
+                ((capy < min_capacity) or (capx < min_capacity))
+        ):
+            name = "{}{}{}".format(RED, name, END)
+        elif (covy > 100) or (covx > 100):
+            name = "{}{}{}".format(CYA, name, END)
+        elif (capy < min_capacity) or (capx < min_capacity):
+            name = "{}{}{}".format(MAG, name, END)
+        colored_names.append(name)
+    colored_names = np.array(colored_names).reshape(-1, 1)
+
+    table = np.hstack((colored_names, shapes, totals, capacity, img_coverage))
+    if detailed:
+        table = np.hstack((table, real_filters.astype(int),
+                           receptive_fields.astype(int)))
+
+    return tabulate(table, header, tablefmt=tablefmt, floatfmt='.2f')

--- a/nolearn/lasagne/util.py
+++ b/nolearn/lasagne/util.py
@@ -130,7 +130,7 @@ def get_conv_infos(net, min_capacity=100. / 6, tablefmt='pipe',
     MAG = ansi.MAGENTA
     RED = ansi.RED
 
-    layers = net.layers_.values()
+    layers = list(net.layers_.values())
     # assume that first layer is input layer
     img_size = list(net.layers_.values())[0].get_output_shape()[2:]
 

--- a/nolearn/tests/test_lasagne.py
+++ b/nolearn/tests/test_lasagne.py
@@ -237,6 +237,7 @@ def test_clone():
         'loss',
         'objective',
         'on_epoch_finished',
+        'on_training_started',
         'on_training_finished',
         'custom_score',
         ):
@@ -584,3 +585,171 @@ class TestSaveWeights():
 
         mock_open.assert_called_with('mypath', 'wb')
         pickle.dump.assert_called_with(nn, mock_open().__enter__(), -1)
+
+
+class TestPrintLayerInfo():
+    @pytest.fixture(scope='session')
+    def X_train(self, mnist):
+        X, y = mnist
+        return X[:100].reshape(-1, 1, 28, 28)
+
+    @pytest.fixture(scope='session')
+    def y_train(self, mnist):
+        X, y = mnist
+        return y[:100]
+
+    @pytest.fixture(scope='session')
+    def nn(self, NeuralNet, X_train, y_train):
+        nn = NeuralNet(
+            layers=[
+                ('input', InputLayer),
+                ('dense0', DenseLayer),
+                ('dense1', DenseLayer),
+                ('output', DenseLayer),
+                ],
+            input_shape=(None, 1, 28, 28),
+            output_num_units=10,
+            output_nonlinearity=softmax,
+
+            more_params=dict(
+                dense0_num_units=16,
+                dense1_num_units=16,
+                ),
+
+            update=nesterov_momentum,
+            update_learning_rate=0.01,
+            update_momentum=0.9,
+
+            max_epochs=3,
+            )
+        nn.initialize()
+
+        return nn
+
+    @pytest.fixture(scope='session')
+    def cnn(self, NeuralNet, X_train, y_train):
+        nn = NeuralNet(
+            layers=[
+                ('input', InputLayer),
+                ('conv1', Conv2DLayer),
+                ('conv2', Conv2DLayer),
+                ('pool2', MaxPool2DLayer),
+                ('conv3', Conv2DLayer),
+                ('output', DenseLayer),
+                ],
+            input_shape=(None, 1, 28, 28),
+            output_num_units=10,
+            output_nonlinearity=softmax,
+
+            more_params=dict(
+                conv1_filter_size=(5, 5), conv1_num_filters=16,
+                conv2_filter_size=(3, 3), conv2_num_filters=16,
+                pool2_pool_size=(8, 8),
+                conv3_filter_size=(3, 3), conv3_num_filters=16,
+                hidden1_num_units=16,
+                ),
+
+            update=nesterov_momentum,
+            update_learning_rate=0.01,
+            update_momentum=0.9,
+
+            max_epochs=3,
+            )
+
+        nn.initialize()
+        return nn
+
+    @pytest.fixture
+    def is_conv2d(self):
+        from nolearn.lasagne.util import is_conv2d
+        return is_conv2d
+
+    @pytest.fixture
+    def is_maxpool2d(self):
+        from nolearn.lasagne.util import is_maxpool2d
+        return is_maxpool2d
+
+    @pytest.fixture
+    def print_info(self):
+        from nolearn.lasagne.handlers import PrintLayerInfo
+        return PrintLayerInfo()
+
+    def test_is_conv2d_net_false(self, nn, is_conv2d):
+        assert is_conv2d(nn.layers_.values()) is False
+
+    def test_is_conv2d_net_true(self, cnn, is_conv2d):
+        assert is_conv2d(cnn.layers_.values()) is True
+
+    def test_is_conv2d_layer(self, nn, cnn, is_conv2d):
+        assert is_conv2d(nn.layers_['input']) is False
+        assert is_conv2d(cnn.layers_['pool2']) is False
+        assert is_conv2d(cnn.layers_['conv1']) is True
+
+    def test_is_maxpool2d_net_false(self, nn, is_maxpool2d):
+        assert is_maxpool2d(nn.layers_.values()) is False
+
+    def test_is_maxpool2d_net_true(self, cnn, is_maxpool2d):
+        assert is_maxpool2d(cnn.layers_.values()) is True
+
+    def test_is_maxpool2d_layer(self, nn, cnn, is_maxpool2d):
+        assert is_maxpool2d(nn.layers_['input']) is False
+        assert is_maxpool2d(cnn.layers_['pool2']) is True
+        assert is_maxpool2d(cnn.layers_['conv1']) is False
+
+    def test_print_layer_info_greeting(self, nn, print_info):
+        # number of learnable parameters is weights + biases:
+        # 28 * 28 * 16 + 16 + 16 * 16 + 16 + 16 * 10 + 10 = 13002
+        expected = '# Neural Network with 13002 learnable parameters\n'
+        message = print_info._get_greeting(nn)
+        assert message == expected
+
+    def test_print_layer_info_plain_nn(self, nn, print_info):
+        expected = """\
+|   # | name   | size    |
+|----:|:-------|:--------|
+|   0 | input  | 1x28x28 |
+|   1 | dense0 | 16      |
+|   2 | dense1 | 16      |
+|   3 | output | 10      |\
+"""
+        message = print_info._get_layer_info_plain(nn)
+        assert message == expected
+
+    def test_print_layer_info_plain_cnn(self, cnn, print_info):
+        expected = """\
+|   # | name   | size     |
+|----:|:-------|:---------|
+|   0 | input  | 1x28x28  |
+|   1 | conv1  | 16x24x24 |
+|   2 | conv2  | 16x22x22 |
+|   3 | pool2  | 16x3x3   |
+|   4 | conv3  | 16x1x1   |
+|   5 | output | 10       |\
+"""
+        message = print_info._get_layer_info_plain(cnn)
+        assert message == expected
+
+    def test_print_layer_info_conv_cnn(self, cnn, print_info):
+        expected = """\
+| name   | size     |   total |   cap. Y [%] |   cap. X [%] |   cov. Y [%] |   cov. X [%] |
+|:-------|:---------|--------:|-------------:|-------------:|-------------:|-------------:|
+| input  | 1x28x28  |     784 |       100.00 |       100.00 |       100.00 |       100.00 |
+| conv1  | 16x24x24 |    9216 |       100.00 |       100.00 |        17.86 |        17.86 |
+| conv2  | 16x22x22 |    7744 |        42.86 |        42.86 |        25.00 |        25.00 |
+| pool2  | 16x3x3   |     144 |        42.86 |        42.86 |        25.00 |        25.00 |
+| conv3  | 16x1x1   |      16 |       104.35 |       104.35 |        82.14 |        82.14 |
+| output | 10       |      10 |       100.00 |       100.00 |       100.00 |       100.00 |\
+"""
+        message, legend = print_info._get_layer_info_conv(cnn)
+        assert message == expected
+
+        expected = """
+Explanation
+    X, Y:    image dimensions
+    cap.:    learning capacity
+    cov.:    coverage of image
+    \x1b[35mmagenta\x1b[0m: capacity too low (<1/6)
+    \x1b[36mcyan\x1b[0m:    image coverage too high (>100%)
+    \x1b[31mred\x1b[0m:     capacity too low and coverage too high
+"""
+        assert legend == expected


### PR DESCRIPTION
By default, PrintLayerInfo is added, which prints the usual layer information for non-CNN.  For CNN, if verbosity >= 2, print additional information about image coverage and capacity.  If verbosity >= 3, even more information about receptive field size and real filter size.  For more, see link to work by Xudong Cao.