### PR TITLE
Don't pickle X and y  when pickling BatchIterator.

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -61,6 +61,16 @@ class BatchIterator(object):
     def transform(self, Xb, yb):
         return Xb, yb
 
+    def __getstate__(self):
+        state = dict(self.__dict__)
+        for attr in ('X', 'y',):
+            if attr in state:
+                del state[attr]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
 
 class NeuralNet(BaseEstimator):
     """A scikit-learn estimator based on Lasagne.


### PR DESCRIPTION
Hi Daniel,
I had problems pickling my networks when using a largish data set. I found the problem to be connected with the Batchiterator which holds a reference to the whole training set and which thus also gets pickled. The current pickle protocol available for python 2.7 can't handle too large arrays (see e.g. [here](https://groups.google.com/forum/#!topic/theano-users/b8C33U4skXI)). 
Since the X and y are set in the `__call__` method, I think they can be removed from `__getstate__`.
