### PR TITLE
Patch: Change color for best train loss from blue to cyan

### DIFF
--- a/nolearn/lasagne/handlers.py
+++ b/nolearn/lasagne/handlers.py
@@ -24,7 +24,7 @@ class PrintLog:
         info_tabulate = OrderedDict([
             ('epoch', info['epoch']),
             ('train loss', "{}{:.5f}{}".format(
-                ansi.BLUE if info['train_loss_best'] else "",
+                ansi.CYAN if info['train_loss_best'] else "",
                 info['train_loss'],
                 ansi.ENDC if info['train_loss_best'] else "",
                 )),


### PR DESCRIPTION
blue is not (always?) shown in ipython notebooks.