### PR TITLE
Allow for multiple input layers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
   - travis_retry pip install -r requirements.txt
   - travis_retry python setup.py dev
-script: travis_wait py.test
+script: py.test
 cache:
   - apt
   - directories:

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -38,6 +38,12 @@ class _dict(dict):
 
 
 def eval_func(func, Xb, yb=None):
+    if isinstance(Xb, dict):
+        kwargs = dict(Xb)
+        if yb is not None:
+            kwargs['y'] = yb
+        return func(**kwargs)
+
     if yb is not None:
         return func(Xb, yb)
     else:

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -172,6 +172,19 @@ class NeuralNet(BaseEstimator):
             else:
                 raise ValueError("Unused kwarg: {}".format(k))
 
+    @staticmethod
+    def _check_good_input(X, y=None):
+        if isinstance(X, dict):
+            lengths = [len(X1) for X1 in X.values()]
+            if len(set(lengths)) > 1:
+                raise ValueError("Not all values of X are of equal length.")
+            x_len = lengths[0]
+        else:
+            x_len = len(X)
+        if y is not None:
+            if len(y) != x_len:
+                raise ValueError("X and y are not of equal length.")
+
     def initialize(self):
         if getattr(self, '_initialized', False):
             return
@@ -296,6 +309,8 @@ class NeuralNet(BaseEstimator):
         return train_iter, eval_iter, predict_iter
 
     def fit(self, X, y):
+        self._check_good_input(X, y)
+
         if self.use_label_encoder:
             self.enc_ = LabelEncoder()
             y = self.enc_.fit_transform(y).astype(np.int32)

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -8,7 +8,7 @@ from warnings import warn
 from time import time
 import pdb
 
-from lasagne.layers import get_output
+from lasagne.layers import get_output, InputLayer
 from lasagne.objectives import categorical_crossentropy
 from lasagne.objectives import mse
 from lasagne.objectives import Objective
@@ -237,7 +237,6 @@ class NeuralNet(BaseEstimator):
                            output_type):
 
         first_layer = list(self.layers_.values())[0]
-        X_batch = first_layer.input_var
         y_batch = output_type('y_batch')
 
         output_layer = list(layers.values())[-1]
@@ -260,7 +259,11 @@ class NeuralNet(BaseEstimator):
         update_params = self._get_params_for('update')
         updates = update(loss_train, all_params, **update_params)
 
-        X_inputs = [theano.Param(X_batch)]
+        input_layers = [layer for layer in layers.values() if isinstance(layer, InputLayer)]
+
+        X_inputs = [theano.Param(input_layer.input_var,
+                                name="%s.X" % input_layer.name)
+                    for input_layer in input_layers]
         inputs = X_inputs + [theano.Param(y_batch)]
 
         train_iter = theano.function(

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -225,7 +225,7 @@ class NeuralNet(BaseEstimator):
             # Any layer other than the first one is assumed to require
             # an 'incoming' paramter.  By default, we'll use the
             # previous layer:
-            if i > 0:
+            if i > 0 and not issubclass(layer_factory, InputLayer):
                 if 'incoming' in layer_kw:
                     layer_kw['incoming'] = self.layers_[
                         layer_kw['incoming']]

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -1,7 +1,9 @@
 import pickle
 
+from lasagne.layers import ConcatLayer
 from lasagne.layers import DenseLayer
 from lasagne.layers import InputLayer
+from lasagne.layers import Layer
 from lasagne.nonlinearities import identity
 from lasagne.nonlinearities import softmax
 from lasagne.objectives import categorical_crossentropy
@@ -86,7 +88,6 @@ def test_lasagne_functional_grid_search(mnist, monkeypatch):
 
     nn = NeuralNet(
         layers=[],
-        X_tensor_type=T.matrix,
         )
 
     param_grid = {
@@ -141,7 +142,6 @@ def test_clone():
         objective=Objective,
         objective_loss_function=categorical_crossentropy,
         batch_iterator_train=BatchIterator(batch_size=100),
-        X_tensor_type=T.matrix,
         y_tensor_type=T.ivector,
         use_label_encoder=False,
         on_epoch_finished=None,
@@ -162,6 +162,7 @@ def test_clone():
         'output_nonlinearity',
         'loss',
         'objective',
+        'X_tensor_type',
         'on_epoch_finished',
         'on_training_started',
         'on_training_finished',
@@ -257,8 +258,9 @@ class TestCheckForUnusedKwargs:
 
 class TestInitializeLayers:
     def test_initialization(self, NeuralNet):
-        input, hidden1, hidden2, output = [
-            Mock(__name__='MockLayer') for i in range(4)]
+        input = Mock(__name__='InputLayer', __bases__=(InputLayer,))
+        hidden1, hidden2, output = [
+            Mock(__name__='MockLayer', __bases__=(Layer,)) for i in range(3)]
         nn = NeuralNet(
             layers=[
                 (input, {'shape': (10, 10), 'name': 'input'}),
@@ -290,8 +292,9 @@ class TestInitializeLayers:
         assert out is nn.layers_['output']
 
     def test_initialization_legacy(self, NeuralNet):
-        input, hidden1, hidden2, output = [
-            Mock(__name__='MockLayer') for i in range(4)]
+        input = Mock(__name__='InputLayer', __bases__=(InputLayer,))
+        hidden1, hidden2, output = [
+            Mock(__name__='MockLayer', __bases__=(Layer,)) for i in range(3)]
         nn = NeuralNet(
             layers=[
                 ('input', input),
@@ -322,8 +325,9 @@ class TestInitializeLayers:
         assert out is nn.layers_['output']
 
     def test_diamond(self, NeuralNet):
-        input, hidden1, hidden2, concat, output = [
-            Mock(__name__='MockLayer') for i in range(5)]
+        input = Mock(__name__='InputLayer', __bases__=(InputLayer,))
+        hidden1, hidden2, concat, output = [
+            Mock(__name__='MockLayer', __bases__=(Layer,)) for i in range(4)]
         nn = NeuralNet(
             layers=[
                 ('input', input),
@@ -346,3 +350,52 @@ class TestInitializeLayers:
             name='concat'
             )
         output.assert_called_with(incoming=concat.return_value, name='output')
+
+
+class TestMultiInputFunctional:
+    @pytest.fixture(scope='session')
+    def net(self, NeuralNet):
+        return NeuralNet(
+            layers=[
+                (InputLayer,
+                 {'name': 'input1', 'shape': (None, 392)}),
+                (DenseLayer,
+                 {'name': 'hidden1', 'num_units': 98}),
+                (InputLayer,
+                 {'name': 'input2', 'shape': (None, 392)}),
+                (DenseLayer,
+                 {'name': 'hidden2', 'num_units': 98}),
+                (ConcatLayer,
+                 {'incomings': ['hidden1', 'hidden2']}),
+                (DenseLayer,
+                 {'name': 'hidden3', 'num_units': 98}),
+                (DenseLayer,
+                 {'name': 'output', 'num_units': 10, 'nonlinearity': softmax}),
+                ],
+
+            update=nesterov_momentum,
+            update_learning_rate=0.01,
+            update_momentum=0.9,
+
+            max_epochs=2,
+            verbose=4,
+            )
+
+    @pytest.fixture(scope='session')
+    def net_fitted(self, net, mnist):
+        X, y = mnist
+        X_train, y_train = X[:10000], y[:10000]
+        X_train1, X_train2 = X_train[:, :392], X_train[:, 392:]
+        return net.fit({'input1': X_train1, 'input2': X_train2}, y_train)
+
+    @pytest.fixture(scope='session')
+    def y_pred(self, net_fitted, mnist):
+        X, y = mnist
+        X_test = X[60000:]
+        X_test1, X_test2 = X_test[:, :392], X_test[:, 392:]
+        return net_fitted.predict({'input1': X_test1, 'input2': X_test2})
+
+    def test_accuracy(self, net_fitted, mnist, y_pred):
+        X, y = mnist
+        y_test = y[60000:]
+        assert accuracy_score(y_pred, y_test) > 0.85

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -352,6 +352,46 @@ class TestInitializeLayers:
         output.assert_called_with(incoming=concat.return_value, name='output')
 
 
+class TestCheckGoodInput:
+    @pytest.fixture
+    def check_good_input(self, NeuralNet):
+        return NeuralNet._check_good_input
+
+    def test_X_and_y_OK(self, check_good_input):
+        check_good_input(
+            np.arange(100).reshape(10, 10),
+            np.arange(10),
+            )
+
+    def test_X_and_y_length_mismatch(self, check_good_input):
+        with pytest.raises(ValueError):
+            check_good_input(
+                np.arange(90).reshape(9, 10),
+                np.arange(10),
+                )
+
+    def test_X_dict_and_y_length_mismatch(self, check_good_input):
+        with pytest.raises(ValueError):
+            check_good_input({
+                'one': np.arange(100).reshape(10, 10),
+                'two': np.arange(90).reshape(9, 10),
+                },
+                np.arange(10),
+                )
+
+    def test_X_OK(self, check_good_input):
+        check_good_input(
+            np.arange(100).reshape(10, 10),
+            )
+
+    def test_X_dict_length_mismatch(self, check_good_input):
+        with pytest.raises(ValueError):
+            check_good_input({
+                'one': np.arange(100).reshape(10, 10),
+                'two': np.arange(90).reshape(9, 10),
+                })
+
+
 class TestMultiInputFunctional:
     @pytest.fixture(scope='session')
     def net(self, NeuralNet):


### PR DESCRIPTION
Here's an example of what this allows.  Note that there's two input layers, and that we pass a dict instead of a single array X when calling fit and predict.

```python
net = NeuralNet(
    layers=[
        (InputLayer,
         {'name': 'input1', 'shape': (None, 392)}),  # !
        (DenseLayer,
         {'name': 'hidden1', 'num_units': 98}),
        (InputLayer,
         {'name': 'input2', 'shape': (None, 392)}),  # !
        (DenseLayer,
         {'name': 'hidden2', 'num_units': 98}),
        (ConcatLayer,
         {'incomings': ['hidden1', 'hidden2']}),
        (DenseLayer,
         {'name': 'hidden3', 'num_units': 98}),
        (DenseLayer,
         {'name': 'output', 'num_units': 10, 'nonlinearity': softmax}),
        ],

    update=nesterov_momentum,
    update_learning_rate=0.01,
    update_momentum=0.9,

    max_epochs=2,
    )

X, y = mnist
X_train, y_train = X[:10000], y[:10000]
X_train1, X_train2 = X_train[:, :392], X_train[:, 392:]
net.fit({'input1': X_train1, 'input2': X_train2}, y_train)  # !

X_test = X[60000:]
X_test1, X_test2 = X_test[:, :392], X_test[:, 392:]
predictions = net_fitted.predict({'input1': X_test1, 'input2': X_test2})  # !
```