### PR TITLE
Remove support for Lasagne's deprecated 'Objective' class.

### DIFF
--- a/nolearn/lasagne/__init__.py
+++ b/nolearn/lasagne/__init__.py
@@ -5,6 +5,7 @@ from .handlers import (
     )
 from .base import (
     BatchIterator,
+    objective,
     NeuralNet,
     TrainSplit,
     )

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -47,7 +47,7 @@ def _sldict(arr, sl):
 
 class Layers(OrderedDict):
     def __getitem__(self, key):
-        if isinstance(key, int):
+        if isinstance(key, (int, slice)):
             return list(self.values()).__getitem__(key)
         else:
             return super(Layers, self).__getitem__(key)

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -45,6 +45,20 @@ def _sldict(arr, sl):
         return arr[sl]
 
 
+class Layers(OrderedDict):
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return list(self.values()).__getitem__(key)
+        else:
+            return super(Layers, self).__getitem__(key)
+
+    def keys(self):
+        return list(super(Layers, self).keys())
+
+    def values(self):
+        return list(super(Layers, self).values())
+
+
 class BatchIterator(object):
     def __init__(self, batch_size):
         self.batch_size = batch_size
@@ -117,7 +131,7 @@ def objective(layers,
               target,
               aggregate=aggregate,
               **kwargs):
-    output_layer = list(layers.values())[-1]
+    output_layer = layers[-1]
     network_output = get_output(output_layer, **kwargs)
     losses = loss_function(network_output, target)
     return aggregate(losses)
@@ -219,7 +233,7 @@ class NeuralNet(BaseEstimator):
                 )
 
     def _check_for_unused_kwargs(self):
-        names = list(self.layers_.keys()) + ['update', 'objective']
+        names = self.layers_.keys() + ['update', 'objective']
         for k in self._kwarg_keys:
             for n in names:
                 prefix = '{}_'.format(n)
@@ -273,7 +287,7 @@ class NeuralNet(BaseEstimator):
     def initialize_layers(self, layers=None):
         if layers is not None:
             self.layers = layers
-        self.layers_ = OrderedDict()
+        self.layers_ = Layers()
 
         layer = None
         for i, layer_def in enumerate(self.layers):
@@ -334,7 +348,7 @@ class NeuralNet(BaseEstimator):
     def _create_iter_funcs(self, layers, objective, update, output_type):
         y_batch = output_type('y_batch')
 
-        output_layer = list(layers.values())[-1]
+        output_layer = layers[-1]
         objective_kw = self._get_params_for('objective')
 
         loss_train = objective(

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -130,9 +130,13 @@ def objective(layers,
               loss_function,
               target,
               aggregate=aggregate,
-              **kwargs):
+              deterministic=False,
+              get_output_kw=None):
+    if get_output_kw is None:
+        get_output_kw = {}
     output_layer = layers[-1]
-    network_output = get_output(output_layer, **kwargs)
+    network_output = get_output(
+        output_layer, deterministic=deterministic, **get_output_kw)
     losses = loss_function(network_output, target)
     return aggregate(losses)
 

--- a/nolearn/lasagne/handlers.py
+++ b/nolearn/lasagne/handlers.py
@@ -106,7 +106,7 @@ class PrintLayerInfo:
         print("## Layer information")
         print("")
 
-        layers_contain_conv2d = is_conv2d(list(nn.layers_.values()))
+        layers_contain_conv2d = is_conv2d(nn.layers_.values())
         if not layers_contain_conv2d or (nn.verbose < 2):
             layer_info = self._get_layer_info_plain(nn)
             legend = None

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -19,6 +19,25 @@ from sklearn.metrics import mean_absolute_error
 import theano.tensor as T
 
 
+class TestLayers:
+    @pytest.fixture
+    def layers(self):
+        from nolearn.lasagne.base import Layers
+        return Layers([('one', 1), ('two', 2), ('three', 3)])
+
+    def test_getitem_with_key(self, layers):
+        assert layers['one'] == 1
+
+    def test_getitem_with_index(self, layers):
+        assert layers[0] == 1
+
+    def test_keys_returns_list(self, layers):
+        assert layers.keys() == ['one', 'two', 'three']
+
+    def test_values_returns_list(self, layers):
+        assert layers.values() == [1, 2, 3]
+
+
 class TestFunctionalMNIST:
     def test_accuracy(self, net_fitted, mnist, y_pred):
         X, y = mnist

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -31,6 +31,9 @@ class TestLayers:
     def test_getitem_with_index(self, layers):
         assert layers[0] == 1
 
+    def test_getitem_with_slice(self, layers):
+        assert layers[:2] == [1, 2]
+
     def test_keys_returns_list(self, layers):
         assert layers.keys() == ['one', 'two', 'three']
 

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -221,6 +221,38 @@ def test_lasagne_functional_regression(boston):
     assert mean_absolute_error(nn.predict(X[300:]), y[300:]) < 3.0
 
 
+class TestDefaultObjective:
+    @pytest.fixture
+    def get_output(self, monkeypatch):
+        from nolearn.lasagne import base
+        get_output_mock = Mock()
+        monkeypatch.setattr(base, 'get_output', get_output_mock)
+        return get_output_mock
+
+    @pytest.fixture
+    def objective(self):
+        from nolearn.lasagne.base import objective
+        return objective
+
+    def test_with_defaults(self, objective, get_output):
+        loss_function, target = Mock(), Mock()
+        loss_function.return_value = np.array([1, 2, 3])
+        result = objective(
+            [1, 2, 3], loss_function=loss_function, target=target)
+        assert result == 2.0
+        get_output.assert_called_with(3, deterministic=False)
+        loss_function.assert_called_with(get_output.return_value, target)
+
+    def test_with_get_output_kw(self, objective, get_output):
+        loss_function, target = Mock(), Mock()
+        loss_function.return_value = np.array([1, 2, 3])
+        objective(
+            [1, 2, 3], loss_function=loss_function, target=target,
+            get_output_kw={'i_was': 'here'},
+            )
+        get_output.assert_called_with(3, deterministic=False, i_was='here')
+
+
 class TestTrainSplit:
     @pytest.fixture
     def TrainSplit(self):

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -7,7 +7,6 @@ from lasagne.layers import Layer
 from lasagne.nonlinearities import identity
 from lasagne.nonlinearities import softmax
 from lasagne.objectives import categorical_crossentropy
-from lasagne.objectives import Objective
 from lasagne.updates import nesterov_momentum
 from mock import Mock
 from mock import patch
@@ -120,6 +119,7 @@ def test_lasagne_functional_grid_search(mnist, monkeypatch):
 def test_clone():
     from nolearn.lasagne import NeuralNet
     from nolearn.lasagne import BatchIterator
+    from nolearn.lasagne import objective
 
     params = dict(
         layers=[
@@ -139,7 +139,7 @@ def test_clone():
         update_momentum=0.9,
 
         regression=False,
-        objective=Objective,
+        objective=objective,
         objective_loss_function=categorical_crossentropy,
         batch_iterator_train=BatchIterator(batch_size=100),
         y_tensor_type=T.ivector,

--- a/nolearn/lasagne/util.py
+++ b/nolearn/lasagne/util.py
@@ -129,9 +129,9 @@ def get_conv_infos(net, min_capacity=100. / 6, detailed=False):
     MAG = ansi.MAGENTA
     RED = ansi.RED
 
-    layers = list(net.layers_.values())
+    layers = net.layers_.values()
     # assume that first layer is input layer
-    img_size = list(net.layers_.values())[0].output_shape[2:]
+    img_size = layers[0].output_shape[2:]
 
     header = ['name', 'size', 'total', 'cap.Y', 'cap.X',
               'cov.Y', 'cov.X']

--- a/nolearn/lasagne/visualize.py
+++ b/nolearn/lasagne/visualize.py
@@ -146,7 +146,7 @@ def occlusion_heatmap(net, x, target, square_length=7):
         raise ValueError("Square length has to be an odd number, instead "
                          "got {}.".format(square_length))
 
-    num_classes = list(net.layers_.values())[-1].num_units
+    num_classes = net.layers_[-1].num_units
     img = x[0].copy()
     shape = x.shape
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ matplotlib
 scikit-learn==0.15.2
 Theano==0.7
 tabulate==0.7.5
-git+https://github.com/benanne/Lasagne.git@4f67fc2774#egg=Lasagne
+git+https://github.com/benanne/Lasagne.git@9d4408f1#egg=Lasagne==0.1.dev


### PR DESCRIPTION
This catches up with the deprecation of the `lasagne.objectives.Objective` class and introduces a new `objective` interface along with a default implementation:

```python
def objective(layers,
              loss_function,
              target,
              aggregate=aggregate,
              **kwargs):
    output_layer = layers[-1]
    network_output = get_output(output_layer, **kwargs)
    losses = loss_function(network_output, target)
    return aggregate(losses)
```

A custom function can be passed as the `objective` parameter.

What do people think of this latest iteration on objective/loss?  ping @erogol @BrianMiner @bobchennan @BenjaminBossan @cancan101 