### PR TITLE
Changed the train_history_ to be None by default for PrintLayerInfo

### DIFF
--- a/nolearn/lasagne/handlers.py
+++ b/nolearn/lasagne/handlers.py
@@ -97,7 +97,7 @@ class PrintLayerInfo:
     def __init__(self):
         pass
 
-    def __call__(self, nn, train_history):
+    def __call__(self, nn, train_history=None):
         if train_history:
             return
 


### PR DESCRIPTION
…this allows us to do things like 'PrintLayerInfo()(net)' instead of 'PrintLayerInfo()(net, None)', which can be useful sometimes.
For instance, when just want to see the information about the net without calling fit, we can use this.