### PR TITLE
Add support for multiple custom scores to the lasagne.NeuralNet class

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -709,10 +709,13 @@ class NeuralNet(BaseEstimator):
 
     @custom_score.setter
     def custom_score(self, scorer):
-        if self.custom_scores and len(self.custom_scores) == 1:
-            self.custom_scores[0] = scorer
+        if self.custom_scores:
+            if len(self.custom_scores) == 1:
+                self.custom_scores[0] = scorer
+            else:
+                raise AttributeError("No custom_score here")
         else:
-            raise AttributeError("No custom_score here")
+            self.custom_scores = [scorer]
 
     @custom_score.deleter
     def custom_score(self):

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -221,6 +221,11 @@ class NeuralNet(BaseEstimator):
                 "It's unnecessary.")  # BBB
 
         if 'custom_score' in kwargs:
+            warn("The 'custom_score' argument has been deprecated, please use "
+                 "the 'custom_scores' parameter instead, which is just "
+                 "a list of custom scores e.g.\n"
+                 "custom_scores=[('abs', lambda y1, y2: abs(y1-y2)), ('over/under', lambda y1,y2: 'over' if y2 >= y1 else 'under')]")
+
             # add it to custom_scores
             if custom_scores is None:
                 custom_scores = [kwargs.pop('custom_score')]

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -172,7 +172,7 @@ class NeuralNet(BaseEstimator):
         regression=False,
         max_epochs=100,
         train_split=TrainSplit(eval_size=0.2),
-        custom_score=None,
+        custom_scores=None,
         X_tensor_type=None,
         y_tensor_type=None,
         use_label_encoder=False,
@@ -220,9 +220,16 @@ class NeuralNet(BaseEstimator):
                 "The 'X_tensor_type' parameter has been removed. "
                 "It's unnecessary.")  # BBB
 
+        if 'custom_score' in kwargs:
+            # add it to custom_scores
+            if custom_scores is None:
+                custom_scores = [kwargs.pop('custom_score')]
+            else:
+                custom_scores.append(kwargs.pop('custom_score'))
+
         if isinstance(layers, Layer):
             layers = _list([layers])
-
+            
         self.layers = layers
         self.update = update
         self.objective = objective
@@ -232,7 +239,7 @@ class NeuralNet(BaseEstimator):
         self.regression = regression
         self.max_epochs = max_epochs
         self.train_split = train_split
-        self.custom_score = custom_score
+        self.custom_scores = custom_scores
         self.y_tensor_type = y_tensor_type
         self.use_label_encoder = use_label_encoder
         self.on_batch_finished = on_batch_finished or []
@@ -505,7 +512,10 @@ class NeuralNet(BaseEstimator):
             train_losses = []
             valid_losses = []
             valid_accuracies = []
-            custom_score = []
+            if self.custom_scores:
+                custom_scores = [[] for _ in self.custom_scores]
+            else:
+                custom_scores = []
 
             t0 = time()
 
@@ -523,15 +533,16 @@ class NeuralNet(BaseEstimator):
                 valid_losses.append(batch_valid_loss)
                 valid_accuracies.append(accuracy)
 
-                if self.custom_score:
+                if self.custom_scores:
                     y_prob = self.apply_batch_func(self.predict_iter_, Xb)
-                    custom_score.append(self.custom_score[1](yb, y_prob))
+                    for custom_scorer, custom_score in zip(self.custom_scores, custom_scores):
+                        custom_score.append(custom_scorer[1](yb, y_prob))
 
             avg_train_loss = np.mean(train_losses)
             avg_valid_loss = np.mean(valid_losses)
             avg_valid_accuracy = np.mean(valid_accuracies)
-            if custom_score:
-                avg_custom_score = np.mean(custom_score)
+            if custom_scores:
+                avg_custom_scores = np.mean(custom_scores, axis=1)
 
             if avg_train_loss < best_train_loss:
                 best_train_loss = avg_train_loss
@@ -547,8 +558,9 @@ class NeuralNet(BaseEstimator):
                 'valid_accuracy': avg_valid_accuracy,
                 'dur': time() - t0,
                 }
-            if self.custom_score:
-                info[self.custom_score[0]] = avg_custom_score
+            if self.custom_scores:
+                for index, custom_score in enumerate(self.custom_scores):
+                    info[custom_score[0]] = avg_custom_scores[index]
             self.train_history_.append(info)
 
             try:

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -224,7 +224,7 @@ class NeuralNet(BaseEstimator):
             warn("The 'custom_score' argument has been deprecated, please use "
                  "the 'custom_scores' parameter instead, which is just "
                  "a list of custom scores e.g.\n"
-                 "custom_scores=[('abs', lambda y1, y2: abs(y1-y2)), ('over/under', lambda y1,y2: 'over' if y2 >= y1 else 'under')]")
+                 "custom_scores=[('first output', lambda y1, y2: abs(y1[0,0]-y2[0,0])), ('second output', lambda y1,y2: abs(y1[0,1]-y2[0,1]))]")
 
             # add it to custom_scores
             if custom_scores is None:
@@ -704,11 +704,3 @@ class NeuralNet(BaseEstimator):
         # This allows us to have **kwargs in __init__ (woot!):
         param_names = super(NeuralNet, self)._get_param_names()
         return param_names + self._kwarg_keys
-
-    @property
-    def custom_score(self):
-        if self.custom_scores and len(self.custom_scores) == 1:
-            return self.custom_scores[0]
-        else:
-            raise AttributeError("No custom_score here")
-

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -699,3 +699,26 @@ class NeuralNet(BaseEstimator):
         # This allows us to have **kwargs in __init__ (woot!):
         param_names = super(NeuralNet, self)._get_param_names()
         return param_names + self._kwarg_keys
+
+    @property
+    def custom_score(self):
+        if self.custom_scores and len(self.custom_scores) == 1:
+            return self.custom_scores[0]
+        else:
+            raise AttributeError("No custom_score here")
+
+    @custom_score.setter
+    def custom_score(self, scorer):
+        if self.custom_scores and len(self.custom_scores) == 1:
+            self.custom_scores[0] = scorer
+        else:
+            raise AttributeError("No custom_score here")
+
+    @custom_score.deleter
+    def custom_score(self):
+        if self.custom_scores and len(self.custom_scores) == 1:
+            self.custom_scores = []
+        else:
+            raise AttributeError("No custom_score here")
+
+    

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -707,21 +707,3 @@ class NeuralNet(BaseEstimator):
         else:
             raise AttributeError("No custom_score here")
 
-    @custom_score.setter
-    def custom_score(self, scorer):
-        if self.custom_scores:
-            if len(self.custom_scores) == 1:
-                self.custom_scores[0] = scorer
-            else:
-                raise AttributeError("No custom_score here")
-        else:
-            self.custom_scores = [scorer]
-
-    @custom_score.deleter
-    def custom_score(self):
-        if self.custom_scores and len(self.custom_scores) == 1:
-            self.custom_scores = []
-        else:
-            raise AttributeError("No custom_score here")
-
-    

--- a/nolearn/lasagne/handlers.py
+++ b/nolearn/lasagne/handlers.py
@@ -43,8 +43,9 @@ class PrintLog:
         if not nn.regression:
             info_tabulate['valid acc'] = info['valid_accuracy']
 
-        if nn.custom_score:
-            info_tabulate[nn.custom_score[0]] = info[nn.custom_score[0]]
+        if nn.custom_scores:
+            for custom_score in nn.custom_scores:
+                info_tabulate[custom_score[0]] = info[custom_score[0]]
 
         info_tabulate['dur'] = "{:.2f}s".format(info['dur'])
 

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -246,7 +246,7 @@ def test_clone():
         'on_batch_finished',
         'on_training_started',
         'on_training_finished',
-        'custom_score',
+        'custom_scores'
         ):
         for par in (params, params1, params2):
             par.pop(ignore, None)

--- a/nolearn/lasagne/tests/test_handlers.py
+++ b/nolearn/lasagne/tests/test_handlers.py
@@ -20,7 +20,7 @@ def test_print_log(mnist):
 
     nn = Mock(
         regression=False,
-        custom_score=('my_score', 0.99),
+        custom_scores=[('my_score', 0.99)],
         )
 
     train_history = [{


### PR DESCRIPTION
The custom_score parameter seemed very useful, but I wanted more. This patch lets a list of ('name', scorer) pairs be passed through the custom_scores parameter.

Passing a single custom_score still works but handlers that run on_epoch_finished that expect self.custom_score to be a pair will most likely break.  (Externals to the library I mean, I modified PrintLog of course).
