### PR TITLE
Legacy init with unicode

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -337,7 +337,7 @@ class NeuralNet(BaseEstimator):
         layer = None
         for i, layer_def in enumerate(self.layers):
 
-            if isinstance(layer_def[0], str):
+            if isinstance(layer_def[0], (str, unicode)):
                 # The legacy format: ('name', Layer)
                 layer_name, layer_factory = layer_def
                 layer_kw = {'name': layer_name}

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -337,7 +337,7 @@ class NeuralNet(BaseEstimator):
         layer = None
         for i, layer_def in enumerate(self.layers):
 
-            if isinstance(layer_def[0], (str, unicode)):
+            if isinstance(layer_def[0], basestring):
                 # The legacy format: ('name', Layer)
                 layer_name, layer_factory = layer_def
                 layer_kw = {'name': layer_name}

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -501,6 +501,24 @@ class TestInitializeLayers:
 
         assert out is nn.layers_['output']
 
+    def test_initialization_legacy_with_unicode_names(self, NeuralNet):
+        # Test whether legacy initialization is triggered; if not,
+        # raises error.
+        input = Mock(__name__='InputLayer', __bases__=(InputLayer,))
+        hidden1, hidden2, output = [
+            Mock(__name__='MockLayer', __bases__=(Layer,)) for i in range(3)]
+        nn = NeuralNet(
+            layers=[
+                (u'input', input),
+                (u'hidden1', hidden1),
+                (u'hidden2', hidden2),
+                (u'output', output),
+                ],
+            input_shape=(10, 10),
+            hidden1_some='param',
+            )
+        nn.initialize_layers()
+
     def test_diamond(self, NeuralNet):
         input = Mock(__name__='InputLayer', __bases__=(InputLayer,))
         hidden1, hidden2, concat, output = [


### PR DESCRIPTION
Legacy layer initialization is now also triggered if layer name is unicode in Python 2.7.