### PR TITLE
added numpy to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     'scikit-learn',
     'tabulate',
     'Lasagne',
+    'numpy==1.9.3',
     ]
 
 tests_require = [


### PR DESCRIPTION
It appears the installation requires numpy. I am running OSX and hit the following problem:

### Instructions

Starting with nothing ....

```
virtualenv --distribute nolearn
cd nolearn
source bin/activate
python setup.py install
```

yeilds the following error:

```
  File "/Users/josephmisiti/mathandpencil/projects/machinelearning/OSS/nolearn/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 623, in install_item
    dists = self.install_eggs(spec, download, tmpdir)
  File "/Users/josephmisiti/mathandpencil/projects/machinelearning/OSS/nolearn/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 809, in install_eggs
    return self.build_and_install(setup_script, setup_base)
  File "/Users/josephmisiti/mathandpencil/projects/machinelearning/OSS/nolearn/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 1015, in build_and_install
    self.run_setup(setup_script, setup_base, args)
  File "/Users/josephmisiti/mathandpencil/projects/machinelearning/OSS/nolearn/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 1000, in run_setup
    run_setup(setup_script, args)
  File "/Users/josephmisiti/mathandpencil/projects/machinelearning/OSS/nolearn/lib/python2.7/site-packages/setuptools/sandbox.py", line 50, in run_setup
    lambda: execfile(
  File "/Users/josephmisiti/mathandpencil/projects/machinelearning/OSS/nolearn/lib/python2.7/site-packages/setuptools/sandbox.py", line 100, in run
    return func()
  File "/Users/josephmisiti/mathandpencil/projects/machinelearning/OSS/nolearn/lib/python2.7/site-packages/setuptools/sandbox.py", line 52, in <lambda>
    {'__file__':setup_script, '__name__':'__main__'}
  File "setup.py", line 173, in <module>

  File "setup.py", line 165, in setup_package

ImportError: No module named numpy.distutils.core
```
so it appears `numpy` is actually a requirement