### PR TITLE
A bug that prevents the use of grid search with lasagne layers as parameters

### DIFF
--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -193,6 +193,24 @@ def test_lasagne_functional_grid_search(mnist, monkeypatch):
         )
 
 
+def test_lasagne_functional_grid_search_architecture(mnist):
+    from nolearn.lasagne import NeuralNet
+    from lasagne import layers
+
+    X, y = mnist
+
+    l_in = layers.InputLayer(shape=(None, X.shape[1]))
+    l_out0 = layers.DenseLayer(l_in, num_units=10)
+    l_out1 = layers.DenseLayer(l_in, num_units=10)
+
+    nn = NeuralNet(l_out0)
+
+    param_grid = {'layers': [l_out0, l_out1]}
+
+    gs = GridSearchCV(nn, param_grid, cv=2, refit=False, verbose=4)
+    gs.fit(X[:1000], y[:1000])
+
+
 def test_clone():
     from nolearn.lasagne import NeuralNet
     from nolearn.lasagne import BatchIterator


### PR DESCRIPTION
Currently, I have only added a failing test and show a way to circumvent the error. I'm not sure what the proper way to fix this should be.

BTW, using the other grid search test (the one right above this one) for this will not result in an error when calling `gs.fit`, presumably because of the mocking.