### PR TITLE
Fix a bug that prevented `plot_occlusion` from working when last layer did not have the `num_units` attribute

### DIFF
--- a/nolearn/lasagne/tests/conftest.py
+++ b/nolearn/lasagne/tests/conftest.py
@@ -7,8 +7,9 @@ from sklearn.utils import shuffle
 
 from lasagne.layers import Conv2DLayer
 from lasagne.layers import DenseLayer
-from lasagne.layers import MaxPool2DLayer
 from lasagne.layers import InputLayer
+from lasagne.layers import MaxPool2DLayer
+from lasagne.layers import NonlinearityLayer
 from lasagne.nonlinearities import softmax
 from lasagne.updates import nesterov_momentum
 
@@ -121,3 +122,27 @@ def net_color_non_square(NeuralNet):
         max_epochs=1,
         )
     return net
+
+
+@pytest.fixture(scope='session')
+def net_with_nonlinearity_layer(NeuralNet):
+    l = InputLayer(shape=(None, 1, 28, 28))
+    l = Conv2DLayer(l, name='conv1', filter_size=(5, 5), num_filters=8)
+    l = MaxPool2DLayer(l, name='pool1', pool_size=(2, 2))
+    l = Conv2DLayer(l, name='conv2', filter_size=(5, 5), num_filters=8)
+    l = MaxPool2DLayer(l, name='pool2', pool_size=(2, 2))
+    l = DenseLayer(l, name='hidden1', num_units=128)
+    l = DenseLayer(l, name='output', nonlinearity=softmax, num_units=10)
+    l = NonlinearityLayer(l)
+
+    return NeuralNet(
+        layers=l,
+
+        update=nesterov_momentum,
+        update_learning_rate=0.01,
+        update_momentum=0.9,
+
+        max_epochs=5,
+        on_epoch_finished=[_OnEpochFinished()],
+        verbose=99,
+        )

--- a/nolearn/lasagne/tests/test_visualize.py
+++ b/nolearn/lasagne/tests/test_visualize.py
@@ -31,6 +31,17 @@ class TestCNNVisualizeFunctions:
         plt.clf()
         plt.cla()
 
+    def test_plot_occlusion_last_layer_has_no_num_units(
+            self, net_with_nonlinearity_layer, X_train, y_train):
+        from nolearn.lasagne.visualize import plot_occlusion
+        net = net_with_nonlinearity_layer
+        net.initialize()
+        plot_occlusion(net, X_train[3:4], [0])
+        plot_occlusion(net, X_train[2:5], [1, 2, 3],
+                       square_length=3, figsize=(5, 5))
+        plt.clf()
+        plt.cla()
+
     def test_plot_occlusion_colored_non_square(
             self, net_color_non_square, X_train, y_train):
         import numpy as np

--- a/nolearn/lasagne/visualize.py
+++ b/nolearn/lasagne/visualize.py
@@ -1,6 +1,7 @@
 from itertools import product
 
 from lasagne.layers import get_output
+from lasagne.layers import get_output_shape
 import matplotlib.pyplot as plt
 import numpy as np
 import theano
@@ -146,7 +147,7 @@ def occlusion_heatmap(net, x, target, square_length=7):
         raise ValueError("Square length has to be an odd number, instead "
                          "got {}.".format(square_length))
 
-    num_classes = net.layers_[-1].num_units
+    num_classes = get_output_shape(net.layers_[-1])[1]
     img = x[0].copy()
     bs, col, s0, s1 = x.shape
 


### PR DESCRIPTION
Now assumes that the number of classes is determined by `get_output_shape(layers_[-1])[1]`.

Should address this [issue](https://github.com/dnouri/nolearn/issues/172).