### PR TITLE
Fixing OrderedDict imports

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -3,7 +3,12 @@ from __future__ import absolute_import
 from .._compat import basestring
 from .._compat import chain_exception
 from .._compat import pickle
-from collections import OrderedDict
+
+try:
+    from collections import OrderedDict
+except:
+    from ordereddict import OrderedDict
+
 import itertools
 from warnings import warn
 from time import time

--- a/nolearn/lasagne/handlers.py
+++ b/nolearn/lasagne/handlers.py
@@ -1,4 +1,8 @@
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except:
+    from ordereddict import OrderedDict
+    
 from csv import DictWriter
 from datetime import datetime
 from functools import reduce

--- a/nolearn/lasagne/tests/test_handlers.py
+++ b/nolearn/lasagne/tests/test_handlers.py
@@ -1,4 +1,8 @@
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except:
+    from ordereddict import OrderedDict
+    
 import pickle
 
 from lasagne.layers import Conv2DLayer


### PR DESCRIPTION
Both on Python3 and Python2 many users get

```
ImportError: cannot import name OrderedDict
```

error. This PR adds `try..except` block to fix this error for those systems having this package available through the `ordereddict` module.