### PR TITLE
Plotting functions works even when a conv layer with 1 filter is used

### DIFF
--- a/nolearn/lasagne/tests/conftest.py
+++ b/nolearn/lasagne/tests/conftest.py
@@ -105,7 +105,7 @@ def net_fitted(net, X_train, y_train):
 @pytest.fixture(scope='session')
 def net_color_non_square(NeuralNet):
     l = InputLayer(shape=(None, 3, 20, 28))
-    l = Conv2DLayer(l, name='conv1', filter_size=(5, 5), num_filters=8)
+    l = Conv2DLayer(l, name='conv1', filter_size=(5, 5), num_filters=1)
     l = MaxPool2DLayer(l, name='pool1', pool_size=(2, 2))
     l = Conv2DLayer(l, name='conv2', filter_size=(5, 5), num_filters=8)
     l = MaxPool2DLayer(l, name='pool2', pool_size=(2, 2))
@@ -121,6 +121,7 @@ def net_color_non_square(NeuralNet):
 
         max_epochs=1,
         )
+    net.initialize()
     return net
 
 
@@ -135,7 +136,7 @@ def net_with_nonlinearity_layer(NeuralNet):
     l = DenseLayer(l, name='output', nonlinearity=softmax, num_units=10)
     l = NonlinearityLayer(l)
 
-    return NeuralNet(
+    net = NeuralNet(
         layers=l,
 
         update=nesterov_momentum,
@@ -146,6 +147,8 @@ def net_with_nonlinearity_layer(NeuralNet):
         on_epoch_finished=[_OnEpochFinished()],
         verbose=99,
         )
+    net.initialize()
+    return net
 
 
 @pytest.fixture

--- a/nolearn/lasagne/tests/test_visualize.py
+++ b/nolearn/lasagne/tests/test_visualize.py
@@ -1,60 +1,78 @@
 import matplotlib.pyplot as plt
+import numpy as np
+import pytest
 
 
 class TestCNNVisualizeFunctions:
+    @pytest.fixture
+    def X_non_square(self, X_train):
+        X = np.hstack(
+            (X_train[:, :20 * 28], X_train[:, :20 * 28], X_train[:, :20 * 28]))
+        X = X.reshape(-1, 3, 20, 28)
+        return X
+
     def test_plot_loss(self, net_fitted):
         from nolearn.lasagne.visualize import plot_loss
         plot_loss(net_fitted)
         plt.clf()
         plt.cla()
 
-    def test_plot_conv_weights(self, net_fitted):
+    def plot_conv_weights(self, net, **kwargs):
         from nolearn.lasagne.visualize import plot_conv_weights
-        plot_conv_weights(net_fitted.layers_['conv1'])
-        plot_conv_weights(net_fitted.layers_['conv2'], figsize=(1, 2))
+        plot_conv_weights(net.layers_['conv1'], **kwargs)
         plt.clf()
         plt.cla()
 
-    def test_plot_conv_activity(self, net_fitted, X_train):
+    @pytest.mark.parametrize('kwargs', [{}, {'figsize': (3, 4)}])
+    def test_plot_conv_weights(self, net_fitted, net_color_non_square, kwargs):
+        # XXX workaround: fixtures cannot be used (yet) in conjunction
+        # with parametrize
+        self.plot_conv_weights(net_fitted, **kwargs)
+        self.plot_conv_weights(net_color_non_square, **kwargs)
+
+    def plot_conv_activity(self, net, X, **kwargs):
         from nolearn.lasagne.visualize import plot_conv_activity
-        plot_conv_activity(net_fitted.layers_['conv1'], X_train[:1])
-        plot_conv_activity(net_fitted.layers_['conv2'], X_train[10:11],
-                           figsize=(3, 4))
+        plot_conv_activity(net.layers_['conv1'], X, **kwargs)
         plt.clf()
         plt.cla()
 
-    def test_plot_occlusion(self, net_fitted, X_train, y_train):
+    @pytest.mark.parametrize('kwargs', [{}, {'figsize': (3, 4)}])
+    def test_plot_conv_activity(
+            self, net_fitted, net_color_non_square, X_train, X_non_square,
+            kwargs):
+        # XXX see above
+        self.plot_conv_activity(net_fitted, X_train[:1], **kwargs)
+        self.plot_conv_activity(net_fitted, X_train[10:11])
+
+        self.plot_conv_activity(
+            net_color_non_square, X_non_square[:1], **kwargs)
+        self.plot_conv_activity(
+            net_color_non_square, X_non_square[10:11], **kwargs)
+
+    def plot_occlusion(self, net, X, y, **kwargs):
         from nolearn.lasagne.visualize import plot_occlusion
-        plot_occlusion(net_fitted, X_train[3:4], [0])
-        plot_occlusion(net_fitted, X_train[2:5], [1, 2, 3],
-                       square_length=3, figsize=(5, 5))
+        plot_occlusion(net, X, y, **kwargs)
         plt.clf()
         plt.cla()
 
-    def test_plot_occlusion_last_layer_has_no_num_units(
-            self, net_with_nonlinearity_layer, X_train, y_train):
-        from nolearn.lasagne.visualize import plot_occlusion
-        net = net_with_nonlinearity_layer
-        net.initialize()
-        plot_occlusion(net, X_train[3:4], [0])
-        plot_occlusion(net, X_train[2:5], [1, 2, 3],
-                       square_length=3, figsize=(5, 5))
-        plt.clf()
-        plt.cla()
+    @pytest.mark.parametrize(
+        'kwargs', [{}, {'square_length': 3, 'figsize': (3, 4)}])
+    def test_plot_occlusion(
+            self, net_fitted, net_color_non_square,
+            net_with_nonlinearity_layer, X_train, X_non_square, kwargs):
+        # XXX see above
+        self.plot_occlusion(net_fitted, X_train[3:4], [0], **kwargs)
+        self.plot_occlusion(net_fitted, X_train[2:5], [1, 2, 3], **kwargs)
 
-    def test_plot_occlusion_colored_non_square(
-            self, net_color_non_square, X_train, y_train):
-        import numpy as np
-        from nolearn.lasagne.visualize import plot_occlusion
-        X = np.hstack(
-            (X_train[:, :20 * 28], X_train[:, :20 * 28], X_train[:, :20 * 28]))
-        X = X.reshape(-1, 3, 20, 28)
+        self.plot_occlusion(
+            net_with_nonlinearity_layer, X_train[3:4], [0], **kwargs)
+        self.plot_occlusion(
+            net_with_nonlinearity_layer, X_train[2:5], [1, 2, 3], **kwargs)
 
-        net_color_non_square.fit(X[:100], y_train[:100])
-        plot_occlusion(net_color_non_square, X[:1], [0])
-        plot_occlusion(net_color_non_square, X[:3], [3, 2, 1])
-        plt.clf()
-        plt.cla()
+        self.plot_occlusion(
+            net_color_non_square, X_non_square[3:4], [0], **kwargs)
+        self.plot_occlusion(
+            net_color_non_square, X_non_square[2:5], [1, 2, 3], **kwargs)
 
     def test_draw_to_file_net(self, net_fitted, tmpdir):
         from nolearn.lasagne.visualize import draw_to_file

--- a/nolearn/lasagne/visualize.py
+++ b/nolearn/lasagne/visualize.py
@@ -12,6 +12,7 @@ import lasagne
 import pydotplus as pydot
 from IPython.display import Image
 
+
 def plot_loss(net):
     train_loss = [row['train_loss'] for row in net.train_history_]
     valid_loss = [row['valid_loss'] for row in net.train_history_]
@@ -39,7 +40,7 @@ def plot_conv_weights(layer, figsize=(6, 6)):
     ncols = nrows
 
     for feature_map in range(shape[1]):
-        figs, axes = plt.subplots(nrows, ncols, figsize=figsize)
+        figs, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
 
         for ax in axes.flatten():
             ax.set_xticks([])
@@ -50,7 +51,7 @@ def plot_conv_weights(layer, figsize=(6, 6)):
             if i >= shape[0]:
                 break
             axes[r, c].imshow(W[i, feature_map], cmap='gray',
-                              interpolation='nearest')
+                              interpolation='none')
     return plt
 
 
@@ -80,9 +81,9 @@ def plot_conv_activity(layer, x, figsize=(6, 8)):
     nrows = np.ceil(np.sqrt(shape[1])).astype(int)
     ncols = nrows
 
-    figs, axes = plt.subplots(nrows + 1, ncols, figsize=figsize)
+    figs, axes = plt.subplots(nrows + 1, ncols, figsize=figsize, squeeze=False)
     axes[0, ncols // 2].imshow(1 - x[0][0], cmap='gray',
-                               interpolation='nearest')
+                               interpolation='none')
     axes[0, ncols // 2].set_title('original')
 
     for ax in axes.flatten():
@@ -98,7 +99,7 @@ def plot_conv_activity(layer, x, figsize=(6, 8)):
             raise ValueError("Wrong number of dimensions, image data should "
                              "have 2, instead got {}".format(ndim))
         axes[r + 1, c].imshow(-activity[0][i], cmap='gray',
-                              interpolation='nearest')
+                              interpolation='none')
     return plt
 
 
@@ -245,7 +246,9 @@ def plot_occlusion(net, X, target, square_length=7, figsize=(9, None)):
     and both images super-imposed.
 
     """
-    return _plot_heat_map(net, X, figsize, lambda net, X, n: occlusion_heatmap(net, X, target[n], square_length))
+    return _plot_heat_map(
+        net, X, figsize, lambda net, X, n: occlusion_heatmap(
+            net, X, target[n], square_length))
 
 
 def saliency_map(input, output, pred, X):
@@ -261,7 +264,8 @@ def saliency_map_net(net, X):
 
 
 def plot_saliency(net, X, figsize=(9, None)):
-    return _plot_heat_map(net, X, figsize, lambda net, X, n: -saliency_map_net(net, X))
+    return _plot_heat_map(
+        net, X, figsize, lambda net, X, n: -saliency_map_net(net, X))
 
 
 def get_hex_color(layer_type):
@@ -274,9 +278,9 @@ def get_hex_color(layer_type):
         - color : string containing a hex color for filling block.
     """
     COLORS = ['#4A88B3', '#98C1DE', '#6CA2C8', '#3173A2', '#17649B',
-        '#FFBB60', '#FFDAA9', '#FFC981', '#FCAC41', '#F29416',
-        '#C54AAA', '#E698D4', '#D56CBE', '#B72F99', '#B0108D',
-        '#75DF54', '#B3F1A0', '#91E875', '#5DD637', '#3FCD12']
+              '#FFBB60', '#FFDAA9', '#FFC981', '#FCAC41', '#F29416',
+              '#C54AAA', '#E698D4', '#D56CBE', '#B72F99', '#B0108D',
+              '#75DF54', '#B3F1A0', '#91E875', '#5DD637', '#3FCD12']
 
     hashed = int(hash(layer_type)) % 5
 
@@ -288,6 +292,7 @@ def get_hex_color(layer_type):
         return COLORS[10:15][hashed]
     else:
         return COLORS[15:20][hashed]
+
 
 def make_pydot_graph(layers, output_shape=True, verbose=False):
     """
@@ -312,21 +317,19 @@ def make_pydot_graph(layers, output_shape=True, verbose=False):
         label = layer_type
         color = get_hex_color(layer_type)
         if verbose:
-            for attr in ['num_filters', 'num_units', 'ds', \
-                            'filter_shape', 'stride', 'strides', 'p']:
+            for attr in ['num_filters', 'num_units', 'ds',
+                         'filter_shape', 'stride', 'strides', 'p']:
                 if hasattr(layer, attr):
-                    label += '\n' + \
-                        '{0}: {1}'.format(attr, getattr(layer, attr))
+                    label += '\n{0}: {1}'.format(attr, getattr(layer, attr))
             if hasattr(layer, 'nonlinearity'):
                 try:
                     nonlinearity = layer.nonlinearity.__name__
                 except AttributeError:
                     nonlinearity = layer.nonlinearity.__class__.__name__
-                label += '\n' + 'nonlinearity: {0}'.format(nonlinearity)
+                label += '\nnonlinearity: {0}'.format(nonlinearity)
 
         if output_shape:
-            label += '\n' + \
-                'Output shape: {0}'.format(layer.output_shape)
+            label += '\nOutput shape: {0}'.format(layer.output_shape)
 
         pydot_nodes[key] = pydot.Node(
             key, label=label, shape='record', fillcolor=color, style='filled')
@@ -357,7 +360,8 @@ def draw_to_file(layers, filename, **kwargs):
             The filename to save output to
         - **kwargs: see docstring of make_pydot_graph for other options
     """
-    layers = layers.get_all_layers() if hasattr(layers, 'get_all_layers') else layers
+    layers = (layers.get_all_layers() if hasattr(layers, 'get_all_layers')
+              else layers)
     dot = make_pydot_graph(layers, **kwargs)
     ext = filename[filename.rfind('.') + 1:]
     with io.open(filename, 'wb') as fid:
@@ -372,6 +376,7 @@ def draw_to_notebook(layers, **kwargs):
             List of layers or the neural net to draw.
         - **kwargs : see the docstring of make_pydot_graph for other options
     """
-    layers = layers.get_all_layers() if hasattr(layers, 'get_all_layers') else layers
+    layers = (layers.get_all_layers() if hasattr(layers, 'get_all_layers')
+              else layers)
     dot = make_pydot_graph(layers, **kwargs)
     return Image(dot.create_png())


### PR DESCRIPTION
List of changes:

* fix bug in several plotting functions that occurs when a conv layer only has 1 filter
* some formatting in `visualize.py`
* use `interpolation='none'` in `visualize.py`
* minor refactoring of tests in `test_visualize.py` (unfortunately, pytest fixtures and parametrize don't cooperate, may change in the future)

This fix should address [this issue](https://github.com/dnouri/nolearn/issues/246).
