### PR TITLE
Fixed bug that occurred when not using validation data

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -602,14 +602,22 @@ class NeuralNet(BaseEstimator):
 
                 if self.custom_scores:
                     y_prob = self.apply_batch_func(self.predict_iter_, Xb)
-                    for custom_scorer, custom_score in zip(self.custom_scores, custom_scores):
+                    for custom_scorer, custom_score in zip(
+                            self.custom_scores, custom_scores):
                         custom_score.append(custom_scorer[1](yb, y_prob))
 
-            avg_train_loss = np.average(train_losses, weights=batch_train_sizes)
-            avg_valid_loss = np.average(valid_losses, weights=batch_valid_sizes)
+            avg_train_loss = np.average(
+                train_losses, weights=batch_train_sizes)
+            if batch_valid_sizes:
+                avg_valid_loss = np.average(
+                    valid_losses, weights=batch_valid_sizes)
+            else:
+                avg_valid_loss = np.nan
+
             avg_valid_accuracy = np.mean(valid_accuracies)
             if custom_scores:
-                avg_custom_scores = np.average(custom_scores, weights=batch_valid_sizes, axis=1)
+                avg_custom_scores = np.average(
+                    custom_scores, weights=batch_valid_sizes, axis=1)
 
             if avg_train_loss < best_train_loss:
                 best_train_loss = avg_train_loss

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -60,6 +60,14 @@ class TestFunctionalToy:
         net = NeuralNet(l, update_learning_rate=0.01)
         return net.fit(X, y)
 
+    def classif_no_valid(self, NeuralNet, X, y):
+        from nolearn.lasagne import TrainSplit
+        l = InputLayer(shape=(None, X.shape[1]))
+        l = DenseLayer(l, num_units=len(np.unique(y)), nonlinearity=softmax)
+        net = NeuralNet(
+            l, update_learning_rate=0.01, train_split=TrainSplit(0))
+        return net.fit(X, y)
+
     def regr(self, NeuralNet, X, y):
         l = InputLayer(shape=(None, X.shape[1]))
         l = DenseLayer(l, num_units=y.shape[1], nonlinearity=None)
@@ -77,6 +85,12 @@ class TestFunctionalToy:
         X = X.astype(floatX)
         y = y.astype(np.int32)
         self.classif(NeuralNet, X, y)
+
+    def test_classif_no_valid_two_classes(self, NeuralNet):
+        X, y = make_classification()
+        X = X.astype(floatX)
+        y = y.astype(np.int32)
+        self.classif_no_valid(NeuralNet, X, y)
 
     def test_regr_one_target(self, NeuralNet):
         X, y = make_regression()


### PR DESCRIPTION
List of changes:

* fixed a bug that occurred when not using `TrainSplit(0)`, which was introduced in a [recent PR](https://github.com/dnouri/nolearn/pull/248)
* add test to catch this kind of error
* add line breaks in base.by
