### PR TITLE
Remove explicit `objective_loss_function` from `NeuralNet`

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -190,7 +190,6 @@ class NeuralNet(BaseEstimator):
         update=nesterov_momentum,
         loss=None,  # BBB
         objective=objective,
-        objective_loss_function=None,
         batch_iterator_train=BatchIterator(batch_size=128),
         batch_iterator_test=BatchIterator(batch_size=128),
         regression=False,
@@ -289,7 +288,6 @@ class NeuralNet(BaseEstimator):
         self.layers = layers
         self.update = update
         self.objective = objective
-        self.objective_loss_function = objective_loss_function
         self.batch_iterator_train = batch_iterator_train
         self.batch_iterator_test = batch_iterator_test
         self.regression = regression


### PR DESCRIPTION
This will allow for `objective` that do not take a `loss_function`.