### PR TITLE
Give on_epoch_completion data set access

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import itertools
 from warnings import warn
 from time import time
+import inspect
 
 from lasagne.layers import get_all_layers
 from lasagne.layers import get_output
@@ -569,6 +570,8 @@ class NeuralNet(BaseEstimator):
 
         num_epochs_past = len(self.train_history_)
 
+        want_dataset = NeuralNet._any_func_has_dataset_args(on_epoch_finished)
+
         while epoch < epochs:
             epoch += 1
 
@@ -592,6 +595,10 @@ class NeuralNet(BaseEstimator):
                 for func in on_batch_finished:
                     func(self, self.train_history_)
 
+            if want_dataset:
+                y_predict = np.zeros_like(y_valid)
+                y_predict_row = 0
+
             batch_valid_sizes = []
             for Xb, yb in self.batch_iterator_test(X_valid, y_valid):
                 batch_valid_loss, accuracy = self.apply_batch_func(
@@ -600,11 +607,17 @@ class NeuralNet(BaseEstimator):
                 valid_accuracies.append(accuracy)
                 batch_valid_sizes.append(len(Xb))
 
-                if self.custom_scores:
+                if self.custom_scores or want_dataset:
                     y_prob = self.apply_batch_func(self.predict_iter_, Xb)
-                    for custom_scorer, custom_score in zip(
-                            self.custom_scores, custom_scores):
-                        custom_score.append(custom_scorer[1](yb, y_prob))
+
+                    if want_dataset:
+                        y_predict[y_predict_row:y_predict_row+len(yb), :, :, :] = y_prob
+                        y_predict_row += len(yb)
+
+                    if self.custom_scores:
+                        for custom_scorer, custom_score in zip(
+                                self.custom_scores, custom_scores):
+                            custom_score.append(custom_scorer[1](yb, y_prob))
 
             avg_train_loss = np.average(
                 train_losses, weights=batch_train_sizes)
@@ -640,12 +653,34 @@ class NeuralNet(BaseEstimator):
 
             try:
                 for func in on_epoch_finished:
-                    func(self, self.train_history_)
+                    if want_dataset and self._has_dataset_args(func):
+                        func(self, self.train_history_, X_valid, y_valid, y_predict)
+                    else:
+                        func(self, self.train_history_)
             except StopIteration:
                 break
 
         for func in on_training_finished:
             func(self, self.train_history_)
+
+    @staticmethod
+    def _has_dataset_args(callable_obj):
+        """Return True if the given callable object has args for X, y, and y_predict.
+
+        'Normal' on_epoch_finished handlers have 3 args, (self, nn, train_history). Look
+        for three more args and return True if found. We don't care what they are named.
+        """
+        call_methods = inspect.getmembers(callable_obj, lambda m: inspect.ismethod(m) and m.__name__ == '__call__')
+        return (len(call_methods) == 1 and
+                len(inspect.getargspec(call_methods[0][1]).args) == 6)
+
+    @staticmethod
+    def _any_func_has_dataset_args(callable_objs):
+        """Return True if any of the given on_epoch_finished functions has dataset args."""
+        for func in callable_objs:
+            if NeuralNet._has_dataset_args(func):
+                return True
+        return False
 
     @staticmethod
     def apply_batch_func(func, Xb, yb=None):


### PR DESCRIPTION
Optionally, on_epoch_completion handlers can specify three additional
parameters, and if present, these parameters would receive X_valid,
y_valid, and y_predict.