### PR TITLE
Network.predict works with multi-outputs

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -413,7 +413,7 @@ class NeuralNet(BaseEstimator):
                                 "'NeuralNet'."
                                 )
             self._output_layers = self.layers
-            return self.layers if len(self.layers)>1 else self.layers[0]
+            return self.layers
 
         # 'self.layers' are a list of '(Layer class, kwargs)', so
         # we'll have to actually instantiate the layers given the
@@ -472,7 +472,7 @@ class NeuralNet(BaseEstimator):
                 self.layers_["LW_%s" % layer_kw['name']] = layer
 
         self._output_layers = [layer]
-        return layer
+        return [layer]
 
     def _create_iter_funcs(self, layers, objective, update, output_type):
         y_batch = output_type('y_batch')

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from .._compat import basestring
 from .._compat import chain_exception
 from .._compat import pickle
-from collections import OrderedDict
+from collections import OrderedDict, Iterable
 import itertools
 from warnings import warn
 from time import time
@@ -84,7 +84,7 @@ class BatchIterator(object):
             sl = slice(i * bs, (i + 1) * bs)
             Xb = _sldict(self.X, sl)
             if self.y is not None:
-                yb = self.y[sl]
+                yb = _sldict(self.y, sl)
             else:
                 yb = None
             yield self.transform(Xb, yb)
@@ -139,11 +139,13 @@ class TrainSplit(object):
                 kf = StratifiedKFold(y, round(1. / self.eval_size))
 
             train_indices, valid_indices = next(iter(kf))
-            X_train, y_train = _sldict(X, train_indices), y[train_indices]
-            X_valid, y_valid = _sldict(X, valid_indices), y[valid_indices]
+            X_train = _sldict(X, train_indices)
+            y_train = _sldict(y, train_indices)
+            X_valid = _sldict(X, valid_indices)
+            y_valid = _sldict(y, valid_indices)
         else:
             X_train, y_train = X, y
-            X_valid, y_valid = _sldict(X, slice(len(y), None)), y[len(y):]
+            X_valid, y_valid = _sldict(X, slice(0,0)), _sldict(y, slice(0,0))
 
         return X_train, X_valid, y_train, y_valid
 
@@ -287,6 +289,8 @@ class NeuralNet(BaseEstimator):
 
         if isinstance(layers, Layer):
             layers = _list([layers])
+        elif isinstance(layers, Iterable):
+            layers = _list(layers)
             
         self.layers = layers
         self.update = update
@@ -363,7 +367,7 @@ class NeuralNet(BaseEstimator):
 
         out = getattr(self, '_output_layer', None)
         if out is None:
-            out = self._output_layer = self.initialize_layers()
+            out = self._output_layers = self.initialize_layers()
         self._check_for_unused_kwargs()
 
         iter_funcs = self._create_iter_funcs(
@@ -408,7 +412,7 @@ class NeuralNet(BaseEstimator):
                                 "instance object as the 'layers' parameter of "
                                 "'NeuralNet'."
                                 )
-            return self.layers[-1]
+            return self.layers   # the list of all output layers
 
         # 'self.layers' are a list of '(Layer class, kwargs)', so
         # we'll have to actually instantiate the layers given the
@@ -466,21 +470,23 @@ class NeuralNet(BaseEstimator):
                 layer = layer_wrapper(layer)
                 self.layers_["LW_%s" % layer_kw['name']] = layer
 
-        return layer
+        return [layer]
 
     def _create_iter_funcs(self, layers, objective, update, output_type):
         y_batch = output_type('y_batch')
 
-        output_layer = layers[-1]
+
         objective_kw = self._get_params_for('objective')
 
         loss_train = objective(
             layers, target=y_batch, **objective_kw)
         loss_eval = objective(
             layers, target=y_batch, deterministic=True, **objective_kw)
+
+        output_layer = self._output_layers
         predict_proba = get_output(output_layer, None, deterministic=True)
         if not self.regression:
-            predict = predict_proba.argmax(axis=1)
+            predict = predict_proba[0].argmax(axis=1)
             accuracy = T.mean(T.eq(predict, y_batch))
         else:
             accuracy = loss_eval
@@ -690,7 +696,8 @@ class NeuralNet(BaseEstimator):
         probas = []
         for Xb, yb in self.batch_iterator_test(X):
             probas.append(self.apply_batch_func(self.predict_iter_, Xb))
-        return np.vstack(probas)
+        output = tuple(np.vstack(o) for o in zip(*probas))
+        return output if len(output) > 1 else output[0]
 
     def predict(self, X):
         if self.regression:

--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -365,9 +365,9 @@ class NeuralNet(BaseEstimator):
         if getattr(self, '_initialized', False):
             return
 
-        out = getattr(self, '_output_layer', None)
+        out = getattr(self, '_output_layers', None)
         if out is None:
-            out = self._output_layers = self.initialize_layers()
+            self.initialize_layers()
         self._check_for_unused_kwargs()
 
         iter_funcs = self._create_iter_funcs(
@@ -412,7 +412,8 @@ class NeuralNet(BaseEstimator):
                                 "instance object as the 'layers' parameter of "
                                 "'NeuralNet'."
                                 )
-            return self.layers   # the list of all output layers
+            self._output_layers = self.layers
+            return self.layers if len(self.layers)>1 else self.layers[0]
 
         # 'self.layers' are a list of '(Layer class, kwargs)', so
         # we'll have to actually instantiate the layers given the
@@ -470,7 +471,8 @@ class NeuralNet(BaseEstimator):
                 layer = layer_wrapper(layer)
                 self.layers_["LW_%s" % layer_kw['name']] = layer
 
-        return [layer]
+        self._output_layers = [layer]
+        return layer
 
     def _create_iter_funcs(self, layers, objective, update, output_type):
         y_batch = output_type('y_batch')

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -835,7 +835,8 @@ class TestGradScale:
 
 
 class TestMultiOutput:
-    def test_layers_included(self, NeuralNet):
+    @pytest.fixture(scope='class')
+    def mo_net(self, NeuralNet):
         def objective(layers_, target, **kwargs):
             out_a_layer = layers_['output_a']
             out_b_layer = layers_['output_b']
@@ -872,10 +873,18 @@ class TestMultiOutput:
                         regression=True,
                         objective=objective)
         net.initialize()
+        return net
 
+    def test_layers_included(self, mo_net):
         expected_names = sorted(["input", "conv1", "conv2",
                                  "hidden_a", "output_a",
                                  "hidden_b", "output_b"])
-        network_names = sorted(list(net.layers_.keys()))
+        network_names = sorted(list(mo_net.layers_.keys()))
 
         assert (expected_names == network_names)
+
+    def test_predict(self, mo_net):
+        dummy_data = np.zeros((2, 1, 28, 28), np.float32)
+        p_cls, p_reg = mo_net.predict(dummy_data)
+        assert(p_cls.shape == (2, 10))
+        assert(p_reg.shape == (2, 1))

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -557,7 +557,7 @@ class TestInitializeLayers:
         layer2 = DenseLayer(layer1, name='output', num_units=2)  # has name
         nn = NeuralNet(layers=layer2)
         out = nn.initialize_layers()
-        assert nn.layers_['output'] == layer2 == out
+        assert nn.layers_['output'] == layer2 == out[0]
         assert nn.layers_['input0'] == layer1
 
     def test_initialization_with_layer_instance_bad_params(self, NeuralNet):
@@ -598,7 +598,7 @@ class TestInitializeLayers:
         output.assert_called_with(
             incoming=hidden2.return_value, name='output')
 
-        assert out is nn.layers_['output']
+        assert out[0] is nn.layers_['output']
 
     def test_initialization_legacy(self, NeuralNet):
         input = Mock(__name__='InputLayer', __bases__=(InputLayer,))
@@ -631,7 +631,7 @@ class TestInitializeLayers:
         output.assert_called_with(
             incoming=hidden2.return_value, name='output')
 
-        assert out is nn.layers_['output']
+        assert out[0] is nn.layers_['output']
 
     def test_initialization_legacy_with_unicode_names(self, NeuralNet):
         # Test whether legacy initialization is triggered; if not,


### PR DESCRIPTION
The initialize layers test are failing because I modified it so that it returned a list of the output layers rather than a single layer.  

Suggestions on how to proceed?

We could have it return a single Layer if only one output is defined, and a list of Layers if multiple are defined.  Internally I could set the protected `_output_layers` variable which is needed later on.