### PR TITLE
Allow layer types to be passed as string

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -5,6 +5,7 @@ from .._compat import chain_exception
 from .._compat import pickle
 from collections import OrderedDict
 import itertools
+from pydoc import locate
 from warnings import warn
 from time import time
 
@@ -416,14 +417,18 @@ class NeuralNet(BaseEstimator):
         layer = None
         for i, layer_def in enumerate(self.layers):
 
-            if isinstance(layer_def[0], basestring):
+            if isinstance(layer_def[1], dict):
+                # Newer format: (Layer, {'layer': 'kwargs'})
+                layer_factory, layer_kw = layer_def
+                layer_kw = layer_kw.copy()
+            else:
                 # The legacy format: ('name', Layer)
                 layer_name, layer_factory = layer_def
                 layer_kw = {'name': layer_name}
-            else:
-                # New format: (Layer, {'layer': 'kwargs'})
-                layer_factory, layer_kw = layer_def
-                layer_kw = layer_kw.copy()
+
+            if isinstance(layer_factory, str):
+                layer_factory = locate(layer_factory)
+                assert layer_factory is not None
 
             if 'name' not in layer_kw:
                 layer_kw['name'] = self._layer_name(layer_factory, i)

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -600,6 +600,16 @@ class TestInitializeLayers:
 
         assert out is nn.layers_['output']
 
+    def test_initializtion_with_tuples_resolve_layers(self, NeuralNet):
+        nn = NeuralNet(
+            layers=[
+                ('lasagne.layers.InputLayer', {'shape': (None, 10)}),
+                ('lasagne.layers.DenseLayer', {'num_units': 33}),
+                ],
+            )
+        out = nn.initialize_layers(nn.layers)
+        assert out.num_units == 33
+
     def test_initialization_legacy(self, NeuralNet):
         input = Mock(__name__='InputLayer', __bases__=(InputLayer,))
         hidden1, hidden2, output = [
@@ -632,6 +642,18 @@ class TestInitializeLayers:
             incoming=hidden2.return_value, name='output')
 
         assert out is nn.layers_['output']
+
+    def test_initializtion_legacy_resolve_layers(self, NeuralNet):
+        nn = NeuralNet(
+            layers=[
+                ('input', 'lasagne.layers.InputLayer'),
+                ('output', 'lasagne.layers.DenseLayer'),
+                ],
+            input_shape=(None, 10),
+            output_num_units=33,
+            )
+        out = nn.initialize_layers(nn.layers)
+        assert out.num_units == 33
 
     def test_initialization_legacy_with_unicode_names(self, NeuralNet):
         # Test whether legacy initialization is triggered; if not,


### PR DESCRIPTION
Allows:

```python
        nn = NeuralNet(
            layers=[
                ('lasagne.layers.InputLayer', {'shape': (None, 10)}),
                ('lasagne.layers.DenseLayer', {'num_units': 33}),
                ],
            )
```