### PR TITLE
NeuralNet.score now uses sklearn.metrics.r2_score (fix #280)

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -25,7 +25,7 @@ from sklearn.base import BaseEstimator
 from sklearn.cross_validation import KFold
 from sklearn.cross_validation import StratifiedKFold
 from sklearn.metrics import accuracy_score
-from sklearn.metrics import mean_squared_error
+from sklearn.metrics import r2_score
 from sklearn.preprocessing import LabelEncoder
 import theano
 from theano import tensor as T
@@ -728,7 +728,7 @@ class NeuralNet(BaseEstimator):
         return np.vstack(outputs)
 
     def score(self, X, y):
-        score = mean_squared_error if self.regression else accuracy_score
+        score = r2_score if self.regression else accuracy_score
         return float(score(self.predict(X), y))
 
     def get_all_layers(self):

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -24,6 +24,7 @@ from sklearn.datasets import make_regression
 from sklearn.grid_search import GridSearchCV
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import mean_absolute_error
+from sklearn.metrics import r2_score
 import theano
 import theano.tensor as T
 
@@ -109,10 +110,12 @@ class TestFunctionalToy:
 
 
 class TestFunctionalMNIST:
-    def test_accuracy(self, net_fitted, mnist, y_pred):
+    def test_accuracy(self, net_fitted, mnist, X_test, y_pred):
         X, y = mnist
         y_test = y[60000:]
-        assert accuracy_score(y_pred, y_test) > 0.85
+        acc = accuracy_score(y_pred, y_test)
+        assert acc > 0.85
+        assert net_fitted.score(X_test, y_test) == acc
 
     def test_train_history(self, net_fitted):
         history = net_fitted.train_history_
@@ -299,6 +302,7 @@ def test_lasagne_functional_regression(boston):
 
     nn.fit(X[:300], y[:300])
     assert mean_absolute_error(nn.predict(X[300:]), y[300:]) < 3.0
+    assert r2_score(nn.predict(X[300:]), y[300:]) == nn.score(X[300:], y[300:])
 
 
 class TestDefaultObjective:


### PR DESCRIPTION
Fixes #280 