### PR TITLE
Prevent creation of tensor with type float64.

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -626,7 +626,7 @@ class NeuralNet(BaseEstimator):
         predict_proba = get_output(output_layer, None, deterministic=True)
         if not self.regression:
             predict = predict_proba[0].argmax(axis=1)
-            accuracy = T.mean(T.eq(predict, y_batch))
+            accuracy = T.mean(T.eq(predict, y_batch), dtype=theano.config.floatX)
         else:
             accuracy = loss_eval
 


### PR DESCRIPTION
Utilizing a `.theanorc` including `floatX=float32` and `warn_float64=warn`, there was a warning when a theano tensor was created here with type float64, which does not yield performant computations on current GPUs. Change it to the desired type defined in the `.theanorc` config.