### PR TITLE
Allow for unused inputs to train function

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -656,6 +656,7 @@ class NeuralNet(BaseEstimator):
             outputs=[loss_train] + scores_train,
             updates=updates,
             allow_input_downcast=True,
+            on_unused_input='ignore',
             )
         eval_iter = theano.function(
             inputs=inputs,


### PR DESCRIPTION
This is useful when your (sole) loss function doesn't depend on labels