### PR TITLE
Making gdbn an extra require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ try:
 except IOError:
     README = CHANGES = ''
 
+
 install_requires = [
-    'gdbn',
     'joblib',
     'scikit-learn',
     'tabulate',
@@ -40,7 +40,11 @@ docs_require = [
     'Sphinx',
     ]
 
-all_require = (visualization_require + tests_require + docs_require)
+gdbn_require = [
+    "gdbn"
+]
+
+all_require = (visualization_require + tests_require + docs_require + gdbn_require)
 
 setup(name='nolearn',
       version=version,
@@ -64,6 +68,7 @@ setup(name='nolearn',
           'visualization': visualization_require,
           'testing': tests_require,
           'docs': docs_require,
+          'gdbn': gdbn_require,
           'all': all_require,
           },
       )


### PR DESCRIPTION
This is a suggested fix for #335 - we just make gdbn an extra require so the core package can be installed without it.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>