### PR TITLE
Update to scikit learn 19.2

### DIFF
--- a/nolearn/lasagne/base.py
+++ b/nolearn/lasagne/base.py
@@ -22,8 +22,7 @@ from lasagne.utils import floatX
 from lasagne.utils import unique
 import numpy as np
 from sklearn.base import BaseEstimator
-from sklearn.cross_validation import KFold
-from sklearn.cross_validation import StratifiedKFold
+from sklearn.model_selection import KFold, StratifiedKFold
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import r2_score
 from sklearn.preprocessing import LabelEncoder

--- a/nolearn/lasagne/tests/test_base.py
+++ b/nolearn/lasagne/tests/test_base.py
@@ -15,14 +15,14 @@ from lasagne.nonlinearities import sigmoid
 from lasagne.objectives import categorical_crossentropy
 from lasagne.objectives import aggregate
 from lasagne.updates import nesterov_momentum
-from mock import Mock
-from mock import patch
+from unittest.mock import Mock
+from unittest.mock import patch
 import numpy as np
 import pytest
 from sklearn.base import clone
 from sklearn.datasets import make_classification
 from sklearn.datasets import make_regression
-from sklearn.grid_search import GridSearchCV
+from sklearn.model_selection import GridSearchCV
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import r2_score

--- a/nolearn/lasagne/tests/test_handlers.py
+++ b/nolearn/lasagne/tests/test_handlers.py
@@ -8,8 +8,8 @@ from lasagne.layers import MaxPool2DLayer
 from lasagne.layers import InputLayer
 from lasagne.nonlinearities import softmax
 from lasagne.updates import nesterov_momentum
-from mock import patch
-from mock import Mock
+from unittest.mock import patch
+from unittest.mock import Mock
 import numpy
 import pytest
 

--- a/nolearn/lasagne/tests/test_visualize.py
+++ b/nolearn/lasagne/tests/test_visualize.py
@@ -8,7 +8,7 @@ class TestCNNVisualizeFunctions:
     def X_non_square(self, X_train):
         X = np.hstack(
             (X_train[:, :20 * 28], X_train[:, :20 * 28], X_train[:, :20 * 28]))
-        X = X.reshape(-1, 3, 20, 28)
+        X = X.reshape((-1, 3, 20, 28))
         return X
 
     def test_plot_loss(self, net_fitted):

--- a/nolearn/overfeat.py
+++ b/nolearn/overfeat.py
@@ -113,7 +113,7 @@ class OverFeatShell(ChunkedTransform, BaseEstimator):
             n_feat, n_rows, n_cols = data[i * 2].split()
             n_feat, n_rows, n_cols = int(n_feat), int(n_rows), int(n_cols)
             feat = np.fromstring(data[i * 2 + 1], dtype=np.float32, sep=' ')
-            feat = feat.reshape(n_feat, n_rows, n_cols)
+            feat = feat.reshape((n_feat, n_rows, n_cols))
             if self.merge == 'maxmean':
                 feat = feat.max(2).mean(1)
             elif self.merge == 'meanmax':

--- a/nolearn/tests/test_cache.py
+++ b/nolearn/tests/test_cache.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 
 def test_cached(tmpdir):

--- a/nolearn/tests/test_grid_search.py
+++ b/nolearn/tests/test_grid_search.py
@@ -1,6 +1,6 @@
 from sklearn.linear_model import LogisticRegression
-from sklearn.grid_search import GridSearchCV
-from mock import Mock
+from sklearn.model_selection import GridSearchCV
+from unittest.mock import Mock
 import numpy as np
 
 

--- a/nolearn/tests/test_metrics.py
+++ b/nolearn/tests/test_metrics.py
@@ -1,6 +1,6 @@
-from mock import Mock
+from unittest.mock import Mock
 import numpy as np
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LogisticRegression
 
 

--- a/nolearn/util.py
+++ b/nolearn/util.py
@@ -6,7 +6,7 @@ import numpy as np
 def chunks(l, n):
     """ Yield successive n-sized chunks from l.
     """
-    for i in xrange(0, len(l), n):
+    for i in range(0, len(l), n):
         yield l[i:i + n]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-numpy==1.10.4
-scipy==0.16.1
+numpy==1.16.3
+scipy==1.2.1
 Theano==0.8
 -e git+https://github.com/Lasagne/Lasagne.git@8f4f9b2#egg=Lasagne==0.2.git
 joblib==0.9.3
-scikit-learn==0.17
+scikit-learn==0.19.2
 tabulate==0.7.5
+matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,4 @@ addopts =
   --flakes
   --pep8
   -v
-  nolearn/tests/ nolearn/lasagne/tests/
 python_files = test*py


### PR DESCRIPTION
Having trouble using nolearn with scikit learn 19.2 due to api changes. I updated the required libraries and fixed a few warnings.